### PR TITLE
[codex] Harden async command refresh context

### DIFF
--- a/custom_components/surepcha/entity.py
+++ b/custom_components/surepcha/entity.py
@@ -8,7 +8,7 @@ from surepcio.devices.device import DeviceBase, PetBase
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from custom_components.surepcha.helper import serialize
+from custom_components.surepcha.helper import ensure_command_device, serialize
 from custom_components.surepcha.method_field import MethodField
 from .const import DOMAIN
 from .coordinator import SurePetCareDeviceDataUpdateCoordinator
@@ -98,8 +98,11 @@ class SurePetCareBaseEntity(CoordinatorEntity[SurePetCareDeviceDataUpdateCoordin
 
     async def _send_command(self, value: Any) -> None:
         """Send command to device."""
-        command = self.entity_description.field(
-            self._device, self.coordinator.config_entry.options, value
+        command = ensure_command_device(
+            self.entity_description.field(
+                self._device, self.coordinator.config_entry.options, value
+            ),
+            self._device,
         )
         logger.debug(
             "send_command for %s: %s=%s (command: %s)",

--- a/custom_components/surepcha/helper.py
+++ b/custom_components/surepcha/helper.py
@@ -3,6 +3,8 @@ from types import MappingProxyType
 from pydantic import BaseModel
 from enum import Enum
 from typing import Any
+from surepcio.command import Command
+from surepcio.devices.device import SurePetCareBase
 from custom_components.surepcha.const import NAME, OPTION_DEVICES, PRODUCT_ID
 
 logger = logging.getLogger(__name__)
@@ -140,3 +142,17 @@ def find_entity_id_by_name(
         ),
         None,
     )
+
+
+def ensure_command_device(
+    command: Command | list[Command] | Any,
+    device: SurePetCareBase,
+) -> Command | list[Command] | Any:
+    """Attach a fallback device to commands missing refresh context."""
+    if isinstance(command, list):
+        return [ensure_command_device(item, device) for item in command]
+
+    if isinstance(command, Command) and command.device is None:
+        command.device = device
+
+    return command

--- a/custom_components/surepcha/services.py
+++ b/custom_components/surepcha/services.py
@@ -8,6 +8,7 @@ from surepcio.devices import Pet
 from custom_components.surepcha.coordinator import (
     SurePetCareDeviceDataUpdateCoordinator,
 )
+from custom_components.surepcha.helper import ensure_command_device
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +57,10 @@ async def async_set_debug_logging(call):
 async def async_set_control(call):
     coordinator = get_coordinator(call.hass, call.data.get("device_id"))
     await coordinator.client.api(
-        coordinator._device.set_control(**call.data.get("control"))
+        ensure_command_device(
+            coordinator._device.set_control(**call.data.get("control")),
+            coordinator._device,
+        )
     )
 
 
@@ -73,9 +77,13 @@ async def async_set_control(call):
 async def async_set_tag(call):
     device_coordinator = get_coordinator(call.hass, call.data.get("device_id"))
     pet_coordinator = get_coordinator(call.hass, call.data.get("pet_id"))
-    await device_coordinator.client.api(
-        device_coordinator._device.set_tag(
-            pet_coordinator._device.tag, ModifyDeviceTag[call.data.get("action")]
+    await pet_coordinator.client.api(
+        ensure_command_device(
+            pet_coordinator._device.set_tag(
+                device_coordinator._device.id,
+                ModifyDeviceTag[call.data.get("action")],
+            ),
+            pet_coordinator._device,
         )
     )
 
@@ -95,9 +103,12 @@ async def set_pet_access_mode(call) -> None:
     device_coordinator = get_coordinator(call.hass, call.data.get("device_id"))
     pet_coordinator = get_coordinator(call.hass, call.data.get("pet_id"))
     await pet_coordinator.client.api(
-        pet_coordinator._device.set_profile(
-            device_coordinator._device.id,
-            PetDeviceLocationProfile[call.data.get("profile")],
+        ensure_command_device(
+            pet_coordinator._device.set_profile(
+                device_coordinator._device.id,
+                PetDeviceLocationProfile[call.data.get("profile")],
+            ),
+            pet_coordinator._device,
         )
     )
 
@@ -116,7 +127,10 @@ async def set_pet_position(call) -> None:
     pet_coordinator = get_coordinator(call.hass, call.data.get("pet_id"))
     device: Pet = pet_coordinator._device
     await pet_coordinator.client.api(
-        device.set_position(PetLocation[call.data.get("action")])
+        ensure_command_device(
+            device.set_position(PetLocation[call.data.get("action")]),
+            device,
+        )
     )
 
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -21,6 +21,26 @@ from pytest_homeassistant_custom_component.common import (
 )
 
 
+def _get_registry_device_ids(device_registry):
+    device_id = [
+        d.id
+        for d in device_registry.devices.values()
+        if any(ident[0] == DOMAIN for ident in d.identifiers)
+        and getattr(d, "model_id", None) != ProductId.PET
+    ][0]
+    pet_id = [
+        d.id
+        for d in device_registry.devices.values()
+        if any(ident[0] == DOMAIN for ident in d.identifiers)
+        and getattr(d, "model_id", None) == ProductId.PET
+    ][0]
+    return device_id, pet_id
+
+
+def _get_surepetcare_id(device_entry) -> str:
+    return next(ident[1] for ident in device_entry.identifiers if ident[0] == DOMAIN)
+
+
 @patch("custom_components.surepcha.PLATFORMS", [Platform.SENSOR])
 @pytest.mark.usefixtures("enable_custom_integrations")
 @pytest.mark.usefixtures("entity_registry_enabled_default")
@@ -71,18 +91,12 @@ async def test_platform_setup_and_set_tag_service(
         hass, mock_client, mock_config_entry, mock_devices, mock_pets
     )
     device_registry = async_get_device_registry(hass)
-    device_id = [
-        d.id
-        for d in device_registry.devices.values()
-        if any(ident[0] == DOMAIN for ident in d.identifiers)
-        and getattr(d, "model_id", None) != ProductId.PET
-    ][0]
-    pet_id = [
-        d.id
-        for d in device_registry.devices.values()
-        if any(ident[0] == DOMAIN for ident in d.identifiers)
-        and getattr(d, "model_id", None) == ProductId.PET
-    ][0]
+    device_id, pet_id = _get_registry_device_ids(device_registry)
+    pet_entry = device_registry.async_get(pet_id)
+    assert pet_entry is not None
+    pet_surepetcare_id = _get_surepetcare_id(pet_entry)
+
+    mock_client.api.reset_mock()
     # Call add action
     await hass.services.async_call(
         DOMAIN,
@@ -94,6 +108,10 @@ async def test_platform_setup_and_set_tag_service(
         },
         blocking=True,
     )
+    remove_command = mock_client.api.await_args_list[0].args[0]
+    assert remove_command.device is not None
+    assert str(remove_command.device.id) == pet_surepetcare_id
+
     # Call remove action
     await hass.services.async_call(
         DOMAIN,
@@ -101,6 +119,9 @@ async def test_platform_setup_and_set_tag_service(
         {"device_id": device_id, "pet_id": pet_id, "action": ModifyDeviceTag.ADD.name},
         blocking=True,
     )
+    add_command = mock_client.api.await_args_list[1].args[0]
+    assert add_command.device is not None
+    assert str(add_command.device.id) == pet_surepetcare_id
 
 
 @patch("custom_components.surepcha.PLATFORMS", [Platform.SENSOR])
@@ -121,18 +142,7 @@ async def test_platform_setup_and_set_pet_access_mode_service(
         hass, mock_client, mock_config_entry, mock_devices, mock_pets
     )
     device_registry = async_get_device_registry(hass)
-    device_id = [
-        d.id
-        for d in device_registry.devices.values()
-        if any(ident[0] == DOMAIN for ident in d.identifiers)
-        and getattr(d, "model_id", None) != ProductId.PET
-    ][0]
-    pet_id = [
-        d.id
-        for d in device_registry.devices.values()
-        if any(ident[0] == DOMAIN for ident in d.identifiers)
-        and getattr(d, "model_id", None) == ProductId.PET
-    ][0]
+    device_id, pet_id = _get_registry_device_ids(device_registry)
     await hass.services.async_call(
         DOMAIN,
         "set_pet_access_mode",
@@ -163,12 +173,12 @@ async def test_platform_setup_and_set_pet_position_service(
         hass, mock_client, mock_config_entry, mock_devices, mock_pets
     )
     device_registry = async_get_device_registry(hass)
-    pet_id = [
-        d.id
-        for d in device_registry.devices.values()
-        if any(ident[0] == DOMAIN for ident in d.identifiers)
-        and getattr(d, "model_id", None) == ProductId.PET
-    ][0]
+    _, pet_id = _get_registry_device_ids(device_registry)
+    pet_entry = device_registry.async_get(pet_id)
+    assert pet_entry is not None
+    pet_surepetcare_id = _get_surepetcare_id(pet_entry)
+
+    mock_client.api.reset_mock()
     await hass.services.async_call(
         DOMAIN,
         "set_pet_position",
@@ -178,3 +188,6 @@ async def test_platform_setup_and_set_pet_position_service(
         },
         blocking=True,
     )
+    command = mock_client.api.await_args_list[0].args[0]
+    assert command.device is not None
+    assert str(command.device.id) == pet_surepetcare_id

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -5,6 +5,9 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.device_registry import async_get as async_get_device_registry
+from surepcio.enums import ProductId
+from custom_components.surepcha.const import DOMAIN
 
 from . import initialize_entry
 
@@ -97,3 +100,51 @@ async def test_switch_toggle_and_snapshot(
         state_off = hass.states.get(entity_id)
         assert state_off is not None
         assert state_off == snapshot(name=f"{entity_id}-off")
+
+
+@patch("custom_components.surepcha.PLATFORMS", [Platform.SWITCH])
+@pytest.mark.usefixtures("enable_custom_integrations")
+@pytest.mark.usefixtures("entity_registry_enabled_default")
+@pytest.mark.asyncio
+async def test_position_switch_sets_command_device(
+    hass: HomeAssistant,
+    mock_client,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    mock_devices,
+    mock_pets,
+) -> None:
+    await initialize_entry(
+        hass, mock_client, mock_config_entry, mock_devices, mock_pets
+    )
+    await hass.async_block_till_done()
+
+    device_registry = async_get_device_registry(hass)
+    pet_entry = next(
+        d
+        for d in device_registry.devices.values()
+        if any(ident[0] == DOMAIN for ident in d.identifiers)
+        and getattr(d, "model_id", None) == ProductId.PET
+    )
+    pet_surepetcare_id = next(
+        ident[1] for ident in pet_entry.identifiers if ident[0] == DOMAIN
+    )
+    position_entity_id = next(
+        entity_id
+        for entity_id in hass.states.async_entity_ids("switch")
+        if entity_id.endswith("_position")
+    )
+
+    mock_client.api.reset_mock()
+
+    await hass.services.async_call(
+        "switch",
+        "turn_on",
+        {"entity_id": position_entity_id},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    command = mock_client.api.await_args_list[0].args[0]
+    assert command.device is not None
+    assert str(command.device.id) == pet_surepetcare_id


### PR DESCRIPTION
## What changed
- route `surepcha.set_tag` through the pet-side `set_tag()` command so async refreshes follow the pet context that owns the assignment
- add `ensure_command_device()` so entity and service calls can attach a fallback device when a command comes back without refresh context
- apply that fallback to service calls and the shared entity command path so pet position updates are covered as well
- add regression coverage for `set_tag`, `set_pet_position`, and the pet position switch path

## Why
The current integration can successfully enqueue some async Sure Petcare actions and still surface an `Unknown error` in Home Assistant afterwards.

The root cause is that the async watcher in `py-surepetcare` expects `command.device` so it can poll and refresh the affected object after the Sure API returns a pending request. In the integration today:
- `surepcha.set_tag` goes through the device-side `set_tag()` path instead of the pet-side one
- some pet position flows can also receive commands without device context

That means the Sure action may still succeed remotely, while Home Assistant fails during the follow-up watcher/refresh step.

## Impact
- `surepcha.set_tag` no longer times out after the device assignment already succeeded remotely
- pet position service and switch flows become more resilient to async commands that arrive without device context
- the change stays local to the integration and does not require an immediate `py-surepetcare` release

## Validation
- `py -m compileall custom_components/surepcha tests`
- full pytest was attempted locally, but this Windows environment could not complete the Home Assistant test dependency install due Python packaging/toolchain issues (`lru-dict` build failure on 3.13 and SSL/build backend issues while trying a 3.12 venv)
