### PR TITLE
Add per-cat feeding sensors, household activity timeline, and config subentries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,9 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
+# Local diagnostic dumps (contain real account data)
+timeline_dump*.json
+
 # pytype static type analyzer
 .pytype/
 

--- a/custom_components/surepcha/__init__.py
+++ b/custom_components/surepcha/__init__.py
@@ -5,7 +5,6 @@ import logging
 from types import MappingProxyType
 from typing import Any, List
 
-from surepcio import SurePetcareClient
 from surepcio import Household
 
 from .services import _service_registry
@@ -26,6 +25,7 @@ from .const import (
     TOKEN,
     OPTION_PROPERTIES,
 )
+from .client import SurePetcareClient
 from .coordinator import SurePetCareDeviceDataUpdateCoordinator, SurePetcareConfigEntry
 from .subentries import subentry_id_for_household
 
@@ -192,6 +192,16 @@ def _move_device_to_subentry(
         )
 
 
+async def _load_household(client: SurePetcareClient, household: Household) -> list[Any]:
+    """Fetch one household's pets and devices, then bind pet-device assignments."""
+    pets, devices = await asyncio.gather(
+        client.api(household.get_pets()),
+        client.api(household.get_devices()),
+    )
+    await client.api(household.fetch_pet_device_assignments())
+    return [*pets, *devices]
+
+
 async def setup_devices(hass, entry) -> tuple[SurePetcareClient, list[Any]]:
     """Setup devices for a config entry, scoped to its household subentries."""
     client: SurePetcareClient = SurePetcareClient()
@@ -218,15 +228,16 @@ async def setup_devices(hass, entry) -> tuple[SurePetcareClient, list[Any]]:
             subentry.data[HOUSEHOLD_ID] for subentry in entry.subentries.values()
         }
         households: List[Household] = await client.api(Household.get_households())
-        entities = []
-        for household in households:
-            if household.id not in household_ids:
-                continue
-            entities.extend(await client.api(household.get_pets()))
-            entities.extend(await client.api(household.get_devices()))
-
-            # Bind pet device assignments
-            await client.api(household.fetch_pet_device_assignments())
+        results = await asyncio.gather(
+            *(
+                _load_household(client, household)
+                for household in households
+                if household.id in household_ids
+            )
+        )
+        entities = [
+            entity for household_entities in results for entity in household_entities
+        ]
         await client.close()
     except Exception as exc:
         await client.close()
@@ -250,12 +261,10 @@ async def async_setup_entry(
         for device in entities
     ]
 
-    await asyncio.gather(
-        *[
-            coordinator.async_config_entry_first_refresh()
-            for coordinator in coordinators
-        ]
-    )
+    # setup_devices() already refreshed every device once via the household
+    # chain, so seed coordinators from that instead of fetching it all again.
+    for coordinator in coordinators:
+        coordinator.async_set_updated_data(coordinator._device)
 
     device_registry = dr.async_get(hass)
     for c in coordinators:

--- a/custom_components/surepcha/__init__.py
+++ b/custom_components/surepcha/__init__.py
@@ -206,10 +206,12 @@ async def setup_devices(hass, entry) -> tuple[SurePetcareClient, list[Any]]:
         """Close connection when hass stops."""
         await client.close()
 
-    # Setup listeners
+    # Setup listeners. Entry unload/reload doesn't fire EVENT_HOMEASSISTANT_STOP,
+    # so close the session on both to avoid leaking it on every reload.
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)
     )
+    entry.async_on_unload(client.close)
     # Fetch devices only for households the user has added as a subentry.
     try:
         household_ids = {

--- a/custom_components/surepcha/__init__.py
+++ b/custom_components/surepcha/__init__.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from types import MappingProxyType
 from typing import Any, List
 
 from surepcio import SurePetcareClient
@@ -11,7 +12,7 @@ from .services import _service_registry
 
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
-from homeassistant.config_entries import ConfigEntry
+from homeassistant.config_entries import ConfigEntry, ConfigSubentry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
@@ -19,11 +20,14 @@ from homeassistant.helpers import device_registry as dr
 from .const import (
     CLIENT_DEVICE_ID,
     DOMAIN,
+    HOUSEHOLD_ID,
+    HOUSEHOLD_SUBENTRY_TYPE,
     MANUAL_PROPERTIES,
     TOKEN,
     OPTION_PROPERTIES,
 )
 from .coordinator import SurePetCareDeviceDataUpdateCoordinator, SurePetcareConfigEntry
+from .subentries import subentry_id_for_household
 
 logger = logging.getLogger(__name__)
 
@@ -63,9 +67,18 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                     )
                 }
             )
-        hass.config_entries.async_update_entry(
-            config_entry, data=new_data, options=new_options, minor_version=2, version=1
-        )
+            hass.config_entries.async_update_entry(
+                config_entry,
+                data=new_data,
+                options=new_options,
+                minor_version=2,
+                version=1,
+            )
+
+        if config_entry.minor_version < 4:
+            if not await _async_migrate_to_household_subentries(hass, config_entry):
+                return False
+            hass.config_entries.async_update_entry(config_entry, minor_version=4)
 
     logger.debug(
         "Migration to configuration version %s.%s successful",
@@ -75,8 +88,112 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     return True
 
 
+async def _async_migrate_to_household_subentries(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> bool:
+    """Give each household on the account its own subentry.
+
+    Only ever sets a device's config_subentry_id — config_entry_id never
+    changes — so existing entity_ids, areas, and history are untouched.
+    Returns False (leaving minor_version unbumped, so HA retries next
+    startup) if households can't be fetched right now.
+    """
+    if config_entry.subentries:
+        # Already migrated, or a fresh entry created post-refactor.
+        return True
+
+    client = SurePetcareClient()
+    try:
+        await client.login(
+            token=config_entry.data.get(TOKEN),
+            device_id=config_entry.data.get(CLIENT_DEVICE_ID),
+        )
+        households: List[Household] = await client.api(Household.get_households())
+        households_with_devices = []
+        for household in households:
+            devices = await client.api(household.get_devices())
+            pets = await client.api(household.get_pets())
+            device_ids = {device.id for device in [*devices, *pets]}
+            if device_ids:
+                households_with_devices.append((household, device_ids))
+    except Exception:
+        logger.warning(
+            "Could not fetch households while migrating entry %s to household "
+            "subentries; will retry on next startup",
+            config_entry.entry_id,
+            exc_info=True,
+        )
+        return False
+    finally:
+        await client.close()
+
+    device_registry = dr.async_get(hass)
+    for household, device_ids in households_with_devices:
+        subentry = ConfigSubentry(
+            subentry_type=HOUSEHOLD_SUBENTRY_TYPE,
+            title=(household.data.get("name") or "").strip()
+            or f"Household {household.id}",
+            unique_id=str(household.id),
+            data=MappingProxyType({HOUSEHOLD_ID: household.id}),
+        )
+        hass.config_entries.async_add_subentry(config_entry, subentry)
+        for device_id in device_ids:
+            registry_entry = device_registry.async_get_device(
+                identifiers={(DOMAIN, str(device_id))}
+            )
+            if registry_entry is not None:
+                _move_device_to_subentry(
+                    device_registry,
+                    registry_entry.id,
+                    config_entry.entry_id,
+                    subentry.subentry_id,
+                )
+
+    return True
+
+
+def _move_device_to_subentry(
+    device_registry: dr.DeviceRegistry,
+    device_id: str,
+    entry_id: str,
+    subentry_id: str,
+) -> None:
+    """Assign a device to its household's subentry, on old- or new-API HA alike."""
+    try:
+        # HA 2026.8+ exposes this single-call API; not yet in older pins, hence
+        # the runtime feature-detection below rather than a version check.
+        device_registry.async_update_device(
+            device_id,
+            new_config_entry_id=entry_id,  # type: ignore[call-arg]
+            new_config_subentry_id=subentry_id,  # type: ignore[call-arg]
+        )
+    except TypeError:
+        # The old API only ever adds associations, never replaces them. A
+        # device registered before subentries existed is associated with
+        # entry_id's "no subentry" bucket (None) - add_config_subentry_id
+        # alone would leave it in *both* that bucket and the real subentry.
+        #
+        # These must be two SEPARATE calls, not combined add_/remove_ kwargs
+        # in one call: HA's device registry computes the remove from the
+        # pre-call state, discarding whatever the add in the same call just
+        # did. For a device with only this one config entry, that computes
+        # an empty entry set and deletes the device outright. Sequencing
+        # them avoids that entirely - confirmed via a regression test that
+        # the device is neither deleted nor left in both buckets.
+        device_registry.async_update_device(
+            device_id,
+            add_config_entry_id=entry_id,
+            add_config_subentry_id=subentry_id,
+        )
+        device_registry.async_update_device(
+            device_id,
+            remove_config_entry_id=entry_id,
+            remove_config_subentry_id=None,
+        )
+
+
 async def setup_devices(hass, entry) -> tuple[SurePetcareClient, list[Any]]:
-    """Setup devices for a config entry."""
+    """Setup devices for a config entry, scoped to its household subentries."""
     client: SurePetcareClient = SurePetcareClient()
     try:
         await client.login(
@@ -93,11 +210,16 @@ async def setup_devices(hass, entry) -> tuple[SurePetcareClient, list[Any]]:
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)
     )
-    # Fetch initial devices
+    # Fetch devices only for households the user has added as a subentry.
     try:
+        household_ids = {
+            subentry.data[HOUSEHOLD_ID] for subentry in entry.subentries.values()
+        }
         households: List[Household] = await client.api(Household.get_households())
         entities = []
         for household in households:
+            if household.id not in household_ids:
+                continue
             entities.extend(await client.api(household.get_pets()))
             entities.extend(await client.api(household.get_devices()))
 
@@ -136,7 +258,7 @@ async def async_setup_entry(
     device_registry = dr.async_get(hass)
     for c in coordinators:
         device = c._device
-        device_registry.async_get_or_create(
+        registry_entry = device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
             identifiers={(DOMAIN, f"{device.id}")},
             manufacturer="SurePetCare",
@@ -144,6 +266,11 @@ async def async_setup_entry(
             model_id=str(device.product_id),
             name=device.name,
         )
+        subentry_id = subentry_id_for_household(entry, device.household_id)
+        if subentry_id is not None:
+            _move_device_to_subentry(
+                device_registry, registry_entry.id, entry.entry_id, subentry_id
+            )
 
     entry.runtime_data = coordinators
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/surepcha/binary_sensor.py
+++ b/custom_components/surepcha/binary_sensor.py
@@ -23,6 +23,7 @@ from .entity import (
     SurePetCareBaseEntity,
     SurePetCareBaseEntityDescription,
 )
+from .subentries import add_entities_by_household
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +140,7 @@ async def async_setup_entry(
         for coordinator in coordinators
         for description in SENSORS.get(coordinator.product_id, ())
     ]
-    async_add_entities(entities)
+    add_entities_by_household(async_add_entities, entry, entities)
 
 
 class SurePetCareBinarySensor(SurePetCareBaseEntity, BinarySensorEntity):

--- a/custom_components/surepcha/button.py
+++ b/custom_components/surepcha/button.py
@@ -15,6 +15,7 @@ from .entity import (
     SurePetCareBaseEntity,
     SurePetCareBaseEntityDescription,
 )
+from .subentries import add_entities_by_household
 
 logger = logging.getLogger(__name__)
 
@@ -54,7 +55,7 @@ async def async_setup_entry(
         for coordinator in coordinators
         for description in BUTTONS.get(coordinator.product_id, ())
     ]
-    async_add_entities(entities)
+    add_entities_by_household(async_add_entities, entry, entities)
 
 
 class SurePetCareButton(SurePetCareBaseEntity, ButtonEntity):

--- a/custom_components/surepcha/client.py
+++ b/custom_components/surepcha/client.py
@@ -1,0 +1,23 @@
+"""SurePetcareClient wrapper that runs chained follow-up commands concurrently."""
+
+import asyncio
+from typing import Union
+
+from surepcio import SurePetcareClient as _SurePetcareClient
+from surepcio.command import Command
+
+
+class SurePetcareClient(_SurePetcareClient):
+    """Execute list[Command] concurrently instead of one request at a time.
+
+    The upstream client's api() awaits a list of chained commands
+    sequentially. Household.get_pets()/get_devices() chain into exactly
+    that - one refresh Command per pet/device - so a household with N pets
+    and M devices costs N+M sequential round trips. Running them
+    concurrently instead cuts that to roughly the slowest single call.
+    """
+
+    async def api(self, command: Union[Command, list[Command]]):
+        if isinstance(command, list):
+            return list(await asyncio.gather(*(self.api(cmd) for cmd in command)))
+        return await super().api(command)

--- a/custom_components/surepcha/config_flow.py
+++ b/custom_components/surepcha/config_flow.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 import logging
 from typing import Any, Mapping
 
-from surepcio import SurePetcareClient
 from surepcio import Household
 from surepcio.enums import ProductId
 from surepcio.security.exceptions import AuthenticationError
@@ -29,6 +28,7 @@ from .const import (
     PRODUCT_ID,
     OPTION_PROPERTIES,
 )
+from .client import SurePetcareClient
 from .device_config_schema import (
     DEVICE_CONFIG_SCHEMAS,
     MANUAL_PROPERTIES,

--- a/custom_components/surepcha/config_flow.py
+++ b/custom_components/surepcha/config_flow.py
@@ -19,6 +19,8 @@ from homeassistant.const import CONF_PASSWORD, CONF_TOKEN, CONF_EMAIL
 from .const import (
     DOMAIN,
     ENTRY_ID,
+    HOUSEHOLD_ID,
+    HOUSEHOLD_SUBENTRY_TYPE,
     NAME,
     OPTION_DEVICES,
     CLIENT_DEVICE_ID,
@@ -44,27 +46,89 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 )
 
 
+async def _authenticate(
+    email=None, password=None, token=None, device_id=None
+) -> tuple[SurePetcareClient, dict]:
+    """Authenticate a fresh client, returning it plus any error keyed for a form."""
+    errors: dict = {}
+    client = SurePetcareClient()
+    logged_in = await client.login(
+        email=email, password=password, token=token, device_id=device_id
+    )
+
+    if not logged_in:
+        errors["base"] = "auth_failed"
+
+    token = getattr(client, TOKEN, None)
+    if not token:
+        errors["base"] = "cannot_connect"
+
+    return client, errors
+
+
+async def _async_fetch_households(client: SurePetcareClient):
+    """Fetch each household's devices/pets, return (households, error).
+
+    Households with no devices or pets are omitted entirely.
+    """
+    errors: dict = {}
+    households: list[Household] = await client.api(Household.get_households())
+    result = []
+    for household in households:
+        devices = await client.api(household.get_devices())
+        pets = await client.api(household.get_pets())
+        combined = {str(d.id): d for d in [*devices, *pets]}
+        if not combined:
+            continue
+        entity_info = {
+            str(device.id): {
+                PRODUCT_ID: getattr(device, PRODUCT_ID, None),
+                NAME: getattr(device, NAME, device.id),
+            }
+            for device in combined.values()
+        }
+        result.append(
+            {
+                "id": household.id,
+                "name": (household.data.get("name") or "").strip(),
+                "entity_info": entity_info,
+            }
+        )
+    if not result:
+        errors["base"] = "no_devices_or_pet_found"
+    return result, errors
+
+
+def _merge_entity_info(households: list[dict]) -> dict:
+    """Merge each household's entity_info into one flat dict, keyed by device id."""
+    merged: dict = {}
+    for household in households:
+        merged.update(household["entity_info"])
+    return merged
+
+
 class SurePetCareConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore
     """Handle a config flow for SurePetCare integration."""
 
     VERSION = 1
-    MINOR_VERSION = 3
+    MINOR_VERSION = 4
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
         """Handle the initial step to login the user"""
         errors: dict = {}
         if user_input is not None:
-            client, error = await self._authenticate(
+            client, error = await _authenticate(
                 email=user_input.get(CONF_EMAIL), password=user_input.get(CONF_PASSWORD)
             )
             errors.update(error)
 
-            entity_info, error = await self._async_fetch_entities(client)
+            households, error = await _async_fetch_households(client)
             errors.update(error)
             await client.close()
             if not errors:
                 logger.debug(
-                    "Configuration complete, updated entities: %s", entity_info
+                    "Configuration complete, households: %s",
+                    [household["id"] for household in households],
                 )
                 return self.async_create_entry(
                     title="SurePetCare Devices",
@@ -73,9 +137,18 @@ class SurePetCareConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: 
                         CLIENT_DEVICE_ID: client.device_id,
                     },
                     options={
-                        OPTION_DEVICES: entity_info,
+                        OPTION_DEVICES: _merge_entity_info(households),
                         OPTION_PROPERTIES: {},
                     },
+                    subentries=[
+                        config_entries.ConfigSubentryData(
+                            title=household["name"] or f"Household {household['id']}",
+                            unique_id=str(household["id"]),
+                            subentry_type=HOUSEHOLD_SUBENTRY_TYPE,
+                            data={HOUSEHOLD_ID: household["id"]},
+                        )
+                        for household in households
+                    ],
                 )
         return self.async_show_form(
             step_id="user",
@@ -83,73 +156,27 @@ class SurePetCareConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: 
             errors=errors,
         )
 
-    async def _async_fetch_entities(self, client: SurePetcareClient):
-        """Authenticate and fetch devices/pets, return (entity_info, error)."""
-        errors = {}
-        households: list[Household] = await client.api(Household.get_households())
-        _devices = {}
-        for household in households:
-            _devices.update(
-                {
-                    str(device.id): device
-                    for device in await client.api(household.get_devices())
-                }
-            )
-            _devices.update(
-                {
-                    str(device.id): device
-                    for device in await client.api(household.get_pets())
-                }
-            )
-        if not _devices:
-            errors["base"] = "no_devices_or_pet_found"
-            return None, errors
-        # Append NAME and PRODUCT_ID to each device in OPTION_DEVICE
-        entity_info = {
-            str(device.id): {
-                PRODUCT_ID: getattr(device, PRODUCT_ID, None),
-                NAME: getattr(device, NAME, device.id),
-            }
-            for device in _devices.values()
-        }
-        return entity_info, errors
-
     async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None):
-        """Migration step in case entities not populated/new device added."""
+        """Refresh device metadata for an existing entry (does not add new households)."""
         entry = self.hass.config_entries.async_get_entry(self.context[ENTRY_ID])
-        client, _ = await self._authenticate(
+        client, _ = await _authenticate(
             token=entry.data[TOKEN], device_id=entry.data[CLIENT_DEVICE_ID]
         )
-        entity_info, _ = await self._async_fetch_entities(client)
+        households, _errors = await _async_fetch_households(client)
         await client.close()
         option_properties = entry.options.get(OPTION_PROPERTIES, {})
         self.hass.config_entries.async_update_entry(
             entry,
             options={
-                OPTION_DEVICES: entity_info,
+                OPTION_DEVICES: _merge_entity_info(households),
                 OPTION_PROPERTIES: option_properties,
             },
         )
-        logger.debug("Reconfiguration complete, updated entities: %s", entity_info)
-        return self.async_abort(reason="entities_reconfigured")
-
-    async def _authenticate(
-        self, email=None, password=None, token=None, device_id=None
-    ) -> tuple[SurePetcareClient, dict]:
-        errors = {}
-        client = SurePetcareClient()
-        logged_in = await client.login(
-            email=email, password=password, token=token, device_id=device_id
+        logger.debug(
+            "Reconfiguration complete, households: %s",
+            [household["id"] for household in households],
         )
-
-        if not logged_in:
-            errors["base"] = "auth_failed"
-
-        token = getattr(client, TOKEN, None)
-        if not token:
-            errors["base"] = "cannot_connect"
-
-        return client, errors
+        return self.async_abort(reason="entities_reconfigured")
 
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]
@@ -163,7 +190,7 @@ class SurePetCareConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: 
         """Dialog that informs the user that reauth is required."""
         reauth_entry = self._get_reauth_entry()
         if user_input is not None:
-            client, errors = await self._authenticate(
+            client, errors = await _authenticate(
                 email=reauth_entry.data[CONF_EMAIL], password=user_input[CONF_PASSWORD]
             )
             await client.close()
@@ -187,6 +214,49 @@ class SurePetCareConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: 
     def async_get_options_flow(config_entry):
         """Return the options flow handler."""
         return SurePetCareOptionsFlow(config_entry)
+
+    @classmethod
+    @callback
+    def async_get_supported_subentry_types(
+        cls, config_entry: config_entries.ConfigEntry
+    ) -> dict[str, type[config_entries.ConfigSubentryFlow]]:
+        """Return subentry types supported by this integration."""
+        return {HOUSEHOLD_SUBENTRY_TYPE: HouseholdSubentryFlow}
+
+
+class HouseholdSubentryFlow(config_entries.ConfigSubentryFlow):
+    """Flow for adding an additional household as a subentry to an existing entry."""
+
+    async def async_step_user(self, user_input: dict[str, Any] | None = None):
+        """Add a household on this account that isn't yet configured."""
+        entry = self._get_entry()
+        client, errors = await _authenticate(
+            token=entry.data[TOKEN], device_id=entry.data[CLIENT_DEVICE_ID]
+        )
+        households: list[dict] = []
+        if not errors:
+            households, fetch_errors = await _async_fetch_households(client)
+            errors.update(fetch_errors)
+        await client.close()
+
+        if errors:
+            return self.async_abort(reason="cannot_connect")
+
+        existing_ids = {subentry.unique_id for subentry in entry.subentries.values()}
+        new_households = [
+            household
+            for household in households
+            if str(household["id"]) not in existing_ids
+        ]
+        if not new_households:
+            return self.async_abort(reason="no_new_household_found")
+
+        household = new_households[0]
+        return self.async_create_entry(
+            title=household["name"] or f"Household {household['id']}",
+            unique_id=str(household["id"]),
+            data={HOUSEHOLD_ID: household["id"]},
+        )
 
 
 class SurePetCareOptionsFlow(config_entries.OptionsFlowWithReload):

--- a/custom_components/surepcha/config_flow.py
+++ b/custom_components/surepcha/config_flow.py
@@ -7,6 +7,7 @@ from typing import Any, Mapping
 from surepcio import SurePetcareClient
 from surepcio import Household
 from surepcio.enums import ProductId
+from surepcio.security.exceptions import AuthenticationError
 
 import voluptuous as vol
 from homeassistant.config_entries import ConfigFlowResult
@@ -52,12 +53,13 @@ async def _authenticate(
     """Authenticate a fresh client, returning it plus any error keyed for a form."""
     errors: dict = {}
     client = SurePetcareClient()
-    logged_in = await client.login(
-        email=email, password=password, token=token, device_id=device_id
-    )
-
-    if not logged_in:
+    try:
+        await client.login(
+            email=email, password=password, token=token, device_id=device_id
+        )
+    except AuthenticationError:
         errors["base"] = "auth_failed"
+        return client, errors
 
     token = getattr(client, TOKEN, None)
     if not token:
@@ -122,8 +124,10 @@ class SurePetCareConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: 
             )
             errors.update(error)
 
-            households, error = await _async_fetch_households(client)
-            errors.update(error)
+            households: list[dict] = []
+            if not errors:
+                households, error = await _async_fetch_households(client)
+                errors.update(error)
             await client.close()
             if not errors:
                 logger.debug(

--- a/custom_components/surepcha/const.py
+++ b/custom_components/surepcha/const.py
@@ -30,6 +30,9 @@ DEVICES = "devices"
 NAME = "name"
 MANUAL_PROPERTIES = "manual_properties"
 
+HOUSEHOLD_ID = "household_id"
+HOUSEHOLD_SUBENTRY_TYPE = "household"
+
 FLAP_PRODUCTS = {
     ProductId.PET_DOOR,
     ProductId.DUAL_SCAN_PET_DOOR,

--- a/custom_components/surepcha/coordinator.py
+++ b/custom_components/surepcha/coordinator.py
@@ -54,10 +54,6 @@ class SurePetCareDeviceDataUpdateCoordinator(DataUpdateCoordinator[T]):
         self.client = client
         self._exception: Exception | None = None
 
-    async def _async_setup(self):
-        """Fetch initial data for the device."""
-        await self.client.api(self._device.refresh())
-
     async def _async_update_data(self) -> Any:
         """Fetch data from the api for a specific device."""
         logger.debug(

--- a/custom_components/surepcha/coordinator.py
+++ b/custom_components/surepcha/coordinator.py
@@ -7,6 +7,11 @@ from surepcio.devices.device import SurePetCareBase
 
 
 from .const import OPTION_DEVICES, POLLING_SPEED, SCAN_INTERVAL
+from .timeline import (
+    HouseholdTimelineData,
+    fetch_household_name,
+    fetch_household_timeline_today,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -60,3 +65,36 @@ class SurePetCareDeviceDataUpdateCoordinator(DataUpdateCoordinator[T]):
         )
         await self.client.api(self._device.refresh())
         return self._device
+
+
+class SurePetCareTimelineCoordinator(DataUpdateCoordinator[HouseholdTimelineData]):
+    """Coordinator aggregating today's feeding stats and activity feed for a household."""
+
+    config_entry: SurePetcareConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: SurePetcareConfigEntry,
+        client: SurePetcareClient,
+        household_id: int,
+    ) -> None:
+        """Initialize household timeline coordinator."""
+        super().__init__(
+            hass,
+            logger,
+            config_entry=entry,
+            name=f"surepetcare timeline household {household_id}",
+            update_interval=timedelta(seconds=SCAN_INTERVAL),
+        )
+        self.client = client
+        self.household_id = household_id
+        self.household_name: str | None = None
+
+    async def _async_update_data(self) -> HouseholdTimelineData:
+        """Fetch and aggregate today's feeding stats and activity feed for the household."""
+        if self.household_name is None:
+            self.household_name = await fetch_household_name(
+                self.client, self.household_id
+            )
+        return await fetch_household_timeline_today(self.client, self.household_id)

--- a/custom_components/surepcha/entity.py
+++ b/custom_components/surepcha/entity.py
@@ -37,6 +37,7 @@ class SurePetCareBaseEntity(CoordinatorEntity[SurePetCareDeviceDataUpdateCoordin
         """Initialize a device."""
         super().__init__(coordinator)
         self._device: DeviceBase | PetBase = coordinator.data
+        self._household_id: int | None = self._device.household_id
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/surepcha/lock.py
+++ b/custom_components/surepcha/lock.py
@@ -13,6 +13,7 @@ from .entity import (
     SurePetCareBaseEntity,
     SurePetCareBaseEntityDescription,
 )
+from .subentries import add_entities_by_household
 from surepcio.enums import ProductId, FlapLocking
 
 logger = logging.getLogger(__name__)
@@ -62,7 +63,7 @@ async def async_setup_entry(
         for coordinator in coordinators
         for description in LOCKS.get(coordinator.product_id, ())
     ]
-    async_add_entities(entities)
+    add_entities_by_household(async_add_entities, entry, entities)
 
 
 class SurePetCareLock(SurePetCareBaseEntity, LockEntity):

--- a/custom_components/surepcha/number.py
+++ b/custom_components/surepcha/number.py
@@ -20,6 +20,7 @@ from .entity import (
     SurePetCareBaseEntity,
     SurePetCareBaseEntityDescription,
 )
+from .subentries import add_entities_by_household
 
 logger = logging.getLogger(__name__)
 
@@ -75,7 +76,7 @@ async def async_setup_entry(
         for coordinator in coordinators
         for description in SENSORS.get(coordinator.product_id, ())
     ]
-    async_add_entities(entities)
+    add_entities_by_household(async_add_entities, entry, entities)
 
 
 class SurePetCareNumber(SurePetCareBaseEntity, NumberEntity):

--- a/custom_components/surepcha/select.py
+++ b/custom_components/surepcha/select.py
@@ -32,6 +32,7 @@ from .entity import (
     SurePetCareBaseEntity,
     SurePetCareBaseEntityDescription,
 )
+from .subentries import add_entities_by_household
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -205,7 +206,7 @@ async def async_setup_entry(
         for coordinator in coordinators
         for description in SELECTS.get(coordinator.product_id, ())
     ]
-    async_add_entities(entities)
+    add_entities_by_household(async_add_entities, entry, entities)
 
 
 class SurePetCareSelect(SurePetCareBaseEntity, SelectEntity):

--- a/custom_components/surepcha/sensor.py
+++ b/custom_components/surepcha/sensor.py
@@ -14,14 +14,16 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.const import PERCENTAGE, UnitOfMass, UnitOfVolume
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from custom_components.surepcha.method_field import MethodField
 
 from .const import (
+    DOMAIN,
     LOCATION_INSIDE,
     LOCATION_OUTSIDE,
     MANUAL_PROPERTIES,
@@ -30,7 +32,11 @@ from .const import (
     PRODUCT_ID,
     OPTION_PROPERTIES,
 )
-from .coordinator import SurePetCareDeviceDataUpdateCoordinator, SurePetcareConfigEntry
+from .coordinator import (
+    SurePetCareDeviceDataUpdateCoordinator,
+    SurePetCareTimelineCoordinator,
+    SurePetcareConfigEntry,
+)
 from .entity import (
     SurePetCareBaseEntity,
     SurePetCareBaseEntityDescription,
@@ -42,6 +48,8 @@ from .helper import (
     option_name,
     stringify,
 )
+from .subentries import add_entities_by_household
+from .timeline import PetFeedingStats
 
 logger = logging.getLogger(__name__)
 
@@ -430,7 +438,7 @@ async def async_setup_entry(
     """Set up SurePetCare sensors for each matching device."""
     coordinators = entry.runtime_data
 
-    entities = [
+    entities: list[SensorEntity] = [
         SurePetCareSensor(
             coordinator,
             description=description,
@@ -438,7 +446,40 @@ async def async_setup_entry(
         for coordinator in coordinators
         for description in SENSORS.get(coordinator.product_id, ())
     ]
-    async_add_entities(entities)
+
+    pet_photos = {
+        coordinator.data.id: coordinator.data.photo
+        for coordinator in coordinators
+        if coordinator.product_id == ProductId.PET
+    }
+    device_photos = {
+        coordinator.data.id: coordinator.data.photo for coordinator in coordinators
+    }
+
+    timeline_coordinators: dict[int, SurePetCareTimelineCoordinator] = {}
+    for coordinator in coordinators:
+        if coordinator.product_id != ProductId.PET:
+            continue
+        household_id = coordinator.data.household_id
+        timeline_coordinator = timeline_coordinators.get(household_id)
+        if timeline_coordinator is None:
+            timeline_coordinator = SurePetCareTimelineCoordinator(
+                hass, entry, coordinator.client, household_id
+            )
+            await timeline_coordinator.async_config_entry_first_refresh()
+            timeline_coordinators[household_id] = timeline_coordinator
+
+            entities.append(
+                SurePetCareHouseholdActivitySensor(
+                    timeline_coordinator, household_id, pet_photos, device_photos
+                )
+            )
+        entities.append(
+            SurePetCareFeedingsTodaySensor(coordinator, timeline_coordinator)
+        )
+        entities.append(SurePetCareFoodTodaySensor(coordinator, timeline_coordinator))
+
+    add_entities_by_household(async_add_entities, entry, entities)
 
 
 class SurePetCareSensor(SurePetCareBaseEntity, SensorEntity):
@@ -466,3 +507,193 @@ class SurePetCareSensor(SurePetCareBaseEntity, SensorEntity):
         ):
             return entity_picture
         return None
+
+
+class SurePetCareTimelineSensorBase(
+    CoordinatorEntity[SurePetCareDeviceDataUpdateCoordinator], SensorEntity
+):
+    """Base for per-pet sensors backed by the household timeline coordinator."""
+
+    _attr_has_entity_name = True
+    _key: str
+
+    def __init__(
+        self,
+        pet_coordinator: SurePetCareDeviceDataUpdateCoordinator,
+        timeline_coordinator: SurePetCareTimelineCoordinator,
+    ) -> None:
+        """Initialize a timeline-backed sensor."""
+        super().__init__(pet_coordinator)
+        self._pet = pet_coordinator.data
+        self._household_id: int | None = self._pet.household_id
+        self._timeline_coordinator = timeline_coordinator
+        self._attr_unique_id = f"{self._pet.id}-{self._key}"
+        self._attr_translation_key = self._key
+
+    async def async_added_to_hass(self) -> None:
+        """Also refresh when the household timeline coordinator updates."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._timeline_coordinator.async_add_listener(
+                self._handle_coordinator_update
+            )
+        )
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return a device description for device registry."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"{self._pet.id}")},
+            manufacturer="SurePetCare",
+            model=self._pet.product_name,
+            model_id=str(self._pet.product_id),
+            name=self._pet.name,
+        )
+
+    @property
+    def _stats(self) -> PetFeedingStats:
+        """Return today's feeding stats for this pet (zeroed if none yet)."""
+        data = self._timeline_coordinator.data
+        feeding_stats = data.feeding_stats if data else {}
+        return feeding_stats.get(self._pet.id, PetFeedingStats())
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return super().available and self._timeline_coordinator.last_update_success
+
+    def _events_attribute(self) -> list[dict[str, Any]]:
+        """Return today's individual feeding events, for use in graphing cards."""
+        return [
+            {
+                "at": event["at"].isoformat(),
+                "device_id": event["device_id"],
+                "grams": event["grams"],
+                "wet_grams": event["wet_grams"],
+                "dry_grams": event["dry_grams"],
+                "duration_seconds": event["duration_seconds"],
+            }
+            for event in self._stats.events
+        ]
+
+
+class SurePetCareFeedingsTodaySensor(SurePetCareTimelineSensorBase):
+    """Number of feeder visits for a pet since local midnight."""
+
+    _key = "feedings_today"
+    _attr_icon = "mdi:counter"
+    _attr_native_unit_of_measurement = "feedings"
+    # Monotonically increases through the day, hard-resets to 0 at local
+    # midnight - TOTAL_INCREASING lets the recorder auto-detect that reset
+    # (via the drop itself) and carry the long-term sum forward correctly.
+    # Plain TOTAL only detects resets via an explicit last_reset attribute,
+    # which we don't provide - without it the midnight drop gets recorded as
+    # a literal decrease and silently corrupts the running statistics sum.
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+
+    @property
+    def native_value(self) -> int:
+        """Return the number of feedings today."""
+        return self._stats.count
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return today's individual feeding events for graphing."""
+        return {
+            "total_grams": self._stats.total_grams,
+            "events": self._events_attribute(),
+        }
+
+
+class SurePetCareFoodTodaySensor(SurePetCareTimelineSensorBase):
+    """Total grams eaten by a pet since local midnight."""
+
+    _key = "food_today"
+    _attr_icon = "mdi:food-drumstick"
+    _attr_device_class = SensorDeviceClass.WEIGHT
+    _attr_native_unit_of_measurement = UnitOfMass.GRAMS
+    # See SurePetCareFeedingsTodaySensor for why TOTAL_INCREASING (not TOTAL).
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+
+    @property
+    def native_value(self) -> float:
+        """Return the total grams eaten today."""
+        return self._stats.total_grams
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return today's individual feeding events for graphing."""
+        return {
+            "count": self._stats.count,
+            "total_wet_grams": self._stats.total_wet_grams,
+            "total_dry_grams": self._stats.total_dry_grams,
+            "events": self._events_attribute(),
+        }
+
+
+class SurePetCareHouseholdActivitySensor(
+    CoordinatorEntity[SurePetCareTimelineCoordinator], SensorEntity
+):
+    """Household-wide chronological feed of feeding and bowl-maintenance activity today."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "household_activity_today"
+    _attr_icon = "mdi:timeline-clock-outline"
+    _attr_native_unit_of_measurement = "events"
+    # See SurePetCareFeedingsTodaySensor for why TOTAL_INCREASING (not TOTAL).
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+
+    def __init__(
+        self,
+        timeline_coordinator: SurePetCareTimelineCoordinator,
+        household_id: int,
+        pet_photos: dict[int, str | None],
+        device_photos: dict[int, str | None],
+    ) -> None:
+        """Initialize the household activity sensor."""
+        super().__init__(timeline_coordinator)
+        self._household_id = household_id
+        self._pet_photos = pet_photos
+        self._device_photos = device_photos
+        self._attr_unique_id = f"household-{household_id}-activity_today"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return a device description for the household itself."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"household-{self._household_id}")},
+            manufacturer="SurePetCare",
+            model="Household",
+            name=self.coordinator.household_name or f"Household {self._household_id}",
+        )
+
+    @property
+    def native_value(self) -> int:
+        """Return the number of activity events recorded today."""
+        data = self.coordinator.data
+        return len(data.activity) if data else 0
+
+    def _pet_photo(self, pet_id: int | None) -> str | None:
+        """Return the pet's photo URL, if this event is tied to a known pet."""
+        return self._pet_photos.get(pet_id) if pet_id is not None else None
+
+    def _device_photo(self, device_id: int | None) -> str | None:
+        """Return the device's photo URL, if this event is tied to a known device."""
+        return self._device_photos.get(device_id) if device_id is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return today's combined feeding and bowl-maintenance activity feed."""
+        data = self.coordinator.data
+        events = data.activity if data else []
+        return {
+            "events": [
+                {
+                    **{key: value for key, value in event.items() if key != "at"},
+                    "at": event["at"].isoformat(),
+                    "pet_photo": self._pet_photo(event.get("pet_id")),
+                    "device_photo": self._device_photo(event.get("device_id")),
+                }
+                for event in events
+            ]
+        }

--- a/custom_components/surepcha/sensor.py
+++ b/custom_components/surepcha/sensor.py
@@ -640,8 +640,9 @@ class SurePetCareHouseholdActivitySensor(
     _attr_translation_key = "household_activity_today"
     _attr_icon = "mdi:timeline-clock-outline"
     _attr_native_unit_of_measurement = "events"
-    # See SurePetCareFeedingsTodaySensor for why TOTAL_INCREASING (not TOTAL).
-    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    # No state_class: this count is redundant with feedings_today's per-pet
+    # statistics, and this entity's real value is the event feed in its
+    # attributes, not a number worth aggregating on its own.
 
     def __init__(
         self,
@@ -673,17 +674,15 @@ class SurePetCareHouseholdActivitySensor(
         data = self.coordinator.data
         return len(data.activity) if data else 0
 
-    def _pet_photo(self, pet_id: int | None) -> str | None:
-        """Return the pet's photo URL, if this event is tied to a known pet."""
-        return self._pet_photos.get(pet_id) if pet_id is not None else None
-
-    def _device_photo(self, device_id: int | None) -> str | None:
-        """Return the device's photo URL, if this event is tied to a known device."""
-        return self._device_photos.get(device_id) if device_id is not None else None
-
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Return today's combined feeding and bowl-maintenance activity feed."""
+        """Return today's combined feeding and bowl-maintenance activity feed.
+
+        Photo URLs are listed once per pet/device rather than repeated on
+        every event - with enough events in a day, duplicating a photo URL
+        on each one is what pushes this past the recorder's 16 KiB per-state
+        attribute limit (silently dropping the attributes from history).
+        """
         data = self.coordinator.data
         events = data.activity if data else []
         return {
@@ -691,9 +690,17 @@ class SurePetCareHouseholdActivitySensor(
                 {
                     **{key: value for key, value in event.items() if key != "at"},
                     "at": event["at"].isoformat(),
-                    "pet_photo": self._pet_photo(event.get("pet_id")),
-                    "device_photo": self._device_photo(event.get("device_id")),
                 }
                 for event in events
-            ]
+            ],
+            "pet_photos": {
+                str(pet_id): photo
+                for pet_id, photo in self._pet_photos.items()
+                if photo is not None
+            },
+            "device_photos": {
+                str(device_id): photo
+                for device_id, photo in self._device_photos.items()
+                if photo is not None
+            },
         }

--- a/custom_components/surepcha/strings.json
+++ b/custom_components/surepcha/strings.json
@@ -69,7 +69,7 @@
           "on": "Online",
           "off": "Offline"
         }
-        
+
       },
       "presence": {
           "name": "Presence",

--- a/custom_components/surepcha/strings.json
+++ b/custom_components/surepcha/strings.json
@@ -273,6 +273,12 @@
         "state_attributes": {
           "events": {
             "name": "Events"
+          },
+          "pet_photos": {
+            "name": "Pet photos"
+          },
+          "device_photos": {
+            "name": "Device photos"
           }
         }
       },

--- a/custom_components/surepcha/subentries.py
+++ b/custom_components/surepcha/subentries.py
@@ -1,0 +1,42 @@
+"""Helpers for scoping entities/devices to their household's config subentry."""
+
+from collections import defaultdict
+from collections.abc import Callable, Sequence
+from typing import TYPE_CHECKING, Any
+
+from .const import HOUSEHOLD_ID
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.entity import Entity
+
+    from .coordinator import SurePetcareConfigEntry
+
+
+def subentry_id_for_household(
+    entry: "SurePetcareConfigEntry", household_id: int | None
+) -> str | None:
+    """Return the subentry_id whose data references this household_id, if any."""
+    if household_id is None:
+        return None
+    return next(
+        (
+            subentry_id
+            for subentry_id, subentry in entry.subentries.items()
+            if subentry.data.get(HOUSEHOLD_ID) == household_id
+        ),
+        None,
+    )
+
+
+def add_entities_by_household(
+    async_add_entities: Callable[..., Any],
+    entry: "SurePetcareConfigEntry",
+    entities: "Sequence[Entity]",
+) -> None:
+    """Group entities by their household and add each group under its subentry."""
+    grouped: dict[str | None, list[Entity]] = defaultdict(list)
+    for entity in entities:
+        household_id = getattr(entity, "_household_id", None)
+        grouped[subentry_id_for_household(entry, household_id)].append(entity)
+    for subentry_id, group in grouped.items():
+        async_add_entities(group, config_subentry_id=subentry_id)

--- a/custom_components/surepcha/switch.py
+++ b/custom_components/surepcha/switch.py
@@ -16,6 +16,7 @@ from .entity import (
     SurePetCareBaseEntity,
     SurePetCareBaseEntityDescription,
 )
+from .subentries import add_entities_by_household
 from surepcio.command import Command
 from surepcio.enums import ProductId, PetDeviceLocationProfile, PetLocation
 from .const import FLAP_PRODUCTS
@@ -123,7 +124,7 @@ async def async_setup_entry(
         for coordinator in coordinators
         for description in SWITCHES.get(coordinator.product_id, ())
     ]
-    async_add_entities(entities)
+    add_entities_by_household(async_add_entities, entry, entities)
 
 
 class SurePetCareSwitch(SurePetCareBaseEntity, SwitchEntity):

--- a/custom_components/surepcha/timeline.py
+++ b/custom_components/surepcha/timeline.py
@@ -1,0 +1,258 @@
+"""Aggregate today's household feeding and bowl-maintenance events from the timeline."""
+
+from collections import defaultdict
+from dataclasses import dataclass, field
+import json
+import logging
+from typing import Any
+
+from surepcio import Household
+from surepcio.client import SurePetcareClient
+from surepcio.enums import FoodType, Tare
+
+from homeassistant.util import dt as dt_util
+
+logger = logging.getLogger(__name__)
+
+# Sure Petcare timeline event types seen in a household's feed:
+# - a pet's feeder visit ("Pet ate")
+# - a feeder bowl being refilled (large weight increase, no pet tag)
+# - a feeder bowl being zeroed/tared (weight reset to 0, no pet tag)
+# These are inferred from field evidence (a zero event immediately followed by
+# a large weight increase on the same device matches a "remove bowl, it reads
+# ~0, refill it, put it back" workflow) rather than documented by the API.
+FEEDING_EVENT_TYPE = 22
+BOWL_FILLED_EVENT_TYPE = 21
+BOWL_ZEROED_EVENT_TYPE = 24
+TIMELINE_EVENT_TYPES = {
+    FEEDING_EVENT_TYPE,
+    BOWL_FILLED_EVENT_TYPE,
+    BOWL_ZEROED_EVENT_TYPE,
+}
+
+MAX_TIMELINE_PAGES = 10
+
+
+@dataclass
+class PetFeedingStats:
+    """Today's feeding activity for a single pet."""
+
+    count: int = 0
+    total_grams: float = 0.0
+    total_wet_grams: float = 0.0
+    total_dry_grams: float = 0.0
+    events: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class HouseholdTimelineData:
+    """Today's household timeline: per-pet feeding stats plus a combined activity feed."""
+
+    feeding_stats: dict[int, PetFeedingStats] = field(default_factory=dict)
+    activity: list[dict[str, Any]] = field(default_factory=list)
+
+
+def _parse_data_blob(event: dict[str, Any]) -> dict[str, Any]:
+    """Parse the event's JSON-encoded 'data' blob, tolerating malformed input."""
+    raw_data = event.get("data")
+    if not raw_data:
+        return {}
+    try:
+        return json.loads(raw_data)
+    except (TypeError, ValueError):
+        return {}
+
+
+def _device_name(event: dict[str, Any], device_id: int | None) -> str | None:
+    """Look up a device's friendly name from the event's embedded device list."""
+    if device_id is None:
+        return None
+    for device in event.get("devices") or []:
+        if device.get("id") == device_id:
+            return device.get("name")
+    return None
+
+
+def _tare_label(tare_type: int | None) -> str | None:
+    """Return a human-readable label for a tare_type code, if known."""
+    if tare_type is None:
+        return None
+    try:
+        return Tare(tare_type).name.lower()
+    except ValueError:
+        return None
+
+
+def _bowl_food_types(event: dict[str, Any]) -> list[int]:
+    """Return the per-bowl food type codes embedded in the event's data blob."""
+    return _parse_data_blob(event).get("weight", {}).get("food_type") or []
+
+
+def _split_by_food_type(
+    event: dict[str, Any], weights: list[dict[str, Any]], *, use_abs: bool
+) -> tuple[float, float, float]:
+    """Split each bowl's weight change into (wet, dry, other) grams.
+
+    use_abs=True for feeding events (frames can be negative "removed" amounts,
+    we want magnitude); use_abs=False for bowl-filled events (raw signed sum
+    is the pre-existing convention there, so wet+dry+other stays == grams).
+    """
+    food_types = _bowl_food_types(event)
+    wet = dry = other = 0.0
+    for weight in weights:
+        for frame in weight.get("frames", []):
+            change = frame.get("change") or 0
+            if use_abs:
+                change = abs(change)
+            index = frame.get("index")
+            food_type = (
+                food_types[index]
+                if index is not None and index < len(food_types)
+                else None
+            )
+            if food_type == FoodType.WET.value:
+                wet += change
+            elif food_type == FoodType.DRY.value:
+                dry += change
+            else:
+                other += change
+    return wet, dry, other
+
+
+async def fetch_household_name(
+    client: SurePetcareClient, household_id: int
+) -> str | None:
+    """Fetch the household's display name (e.g. for use as a device/title name).
+
+    Best-effort: a failure here shouldn't take down feeding/activity polling,
+    so any error is swallowed and treated as "name unknown".
+    """
+    try:
+        household = await client.api(Household.get_household(household_id))
+    except Exception:
+        logger.debug(
+            "Failed to fetch household name for household %s",
+            household_id,
+            exc_info=True,
+        )
+        return None
+    name = household.data.get("name")
+    return name.strip() if isinstance(name, str) and name.strip() else None
+
+
+async def fetch_household_timeline_today(
+    client: SurePetcareClient, household_id: int
+) -> HouseholdTimelineData:
+    """Page back through the household timeline and build today's feeding stats + activity feed."""
+    household = Household({"id": household_id})
+    cutoff = dt_util.start_of_local_day()
+    events_by_pet: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    activity: list[dict[str, Any]] = []
+    before_id: int | None = None
+
+    for _ in range(MAX_TIMELINE_PAGES):
+        batch = await client.api(household.get_timeline(before_id=before_id))
+        if not batch:
+            break
+
+        oldest_in_batch = None
+        for event in batch:
+            at = dt_util.parse_datetime(event.get("created_at") or "")
+            if at is None:
+                continue
+            if oldest_in_batch is None or at < oldest_in_batch:
+                oldest_in_batch = at
+
+            event_type = event.get("type")
+            if event_type not in TIMELINE_EVENT_TYPES or at < cutoff:
+                continue
+
+            weights = event.get("weights") or []
+            device_id = weights[0].get("device_id") if weights else None
+            device_name = _device_name(event, device_id)
+
+            if event_type == FEEDING_EVENT_TYPE:
+                pets = event.get("pets") or []
+                if not pets or "id" not in pets[0]:
+                    continue
+
+                # Each timeline event is already one complete, finalized feeder
+                # visit (not an incremental progress update) — the API reports
+                # its own duration alongside the weight change.
+                wet_grams, dry_grams, other_grams = _split_by_food_type(
+                    event, weights, use_abs=True
+                )
+
+                duration_seconds = weights[0].get("duration") if weights else None
+                pet_id = pets[0]["id"]
+                pet_name = pets[0].get("name")
+                reading = {
+                    "at": at,
+                    "device_id": device_id,
+                    "grams": round(wet_grams + dry_grams + other_grams, 1),
+                    "wet_grams": round(wet_grams, 1),
+                    "dry_grams": round(dry_grams, 1),
+                    "duration_seconds": duration_seconds,
+                }
+                events_by_pet[pet_id].append(reading)
+                activity.append(
+                    {
+                        "at": at,
+                        "activity_type": "feeding",
+                        "pet_id": pet_id,
+                        "pet_name": pet_name,
+                        "device_id": device_id,
+                        "device_name": device_name,
+                        **{k: v for k, v in reading.items() if k != "at"},
+                    }
+                )
+
+            elif event_type == BOWL_FILLED_EVENT_TYPE:
+                fill_wet, fill_dry, fill_other = _split_by_food_type(
+                    event, weights, use_abs=False
+                )
+                activity.append(
+                    {
+                        "at": at,
+                        "activity_type": "bowl_filled",
+                        "device_id": device_id,
+                        "device_name": device_name,
+                        "grams": round(fill_wet + fill_dry + fill_other, 1),
+                        "wet_grams": round(fill_wet, 1),
+                        "dry_grams": round(fill_dry, 1),
+                    }
+                )
+
+            elif event_type == BOWL_ZEROED_EVENT_TYPE:
+                tare_type = _parse_data_blob(event).get("tare_type")
+                activity.append(
+                    {
+                        "at": at,
+                        "activity_type": "bowl_zeroed",
+                        "device_id": device_id,
+                        "device_name": device_name,
+                        "tare_type": tare_type,
+                        "tare_label": _tare_label(tare_type),
+                    }
+                )
+
+        ids = [event["id"] for event in batch if "id" in event]
+        if not ids:
+            break
+        before_id = min(ids)
+
+        if oldest_in_batch is not None and oldest_in_batch < cutoff:
+            break
+
+    feeding_stats = {
+        pet_id: PetFeedingStats(
+            count=len(events),
+            total_grams=round(sum(event["grams"] for event in events), 1),
+            total_wet_grams=round(sum(event["wet_grams"] for event in events), 1),
+            total_dry_grams=round(sum(event["dry_grams"] for event in events), 1),
+            events=sorted(events, key=lambda event: event["at"]),
+        )
+        for pet_id, events in events_by_pet.items()
+    }
+    activity.sort(key=lambda event: event["at"])
+    return HouseholdTimelineData(feeding_stats=feeding_stats, activity=activity)

--- a/custom_components/surepcha/translations/de.json
+++ b/custom_components/surepcha/translations/de.json
@@ -239,6 +239,42 @@
           }
         }
       },
+      "feedings_today": {
+        "name": "Fütterungen heute",
+        "state_attributes": {
+          "total_grams": {
+            "name": "Gramm gesamt"
+          },
+          "events": {
+            "name": "Ereignisse"
+          }
+        }
+      },
+      "food_today": {
+        "name": "Futter heute",
+        "state_attributes": {
+          "count": {
+            "name": "Anzahl"
+          },
+          "total_wet_grams": {
+            "name": "Gramm Nassfutter gesamt"
+          },
+          "total_dry_grams": {
+            "name": "Gramm Trockenfutter gesamt"
+          },
+          "events": {
+            "name": "Ereignisse"
+          }
+        }
+      },
+      "household_activity_today": {
+        "name": "Haushaltsaktivität heute",
+        "state_attributes": {
+          "events": {
+            "name": "Ereignisse"
+          }
+        }
+      },
       "position": {
         "name": "Position",
         "state": {

--- a/custom_components/surepcha/translations/de.json
+++ b/custom_components/surepcha/translations/de.json
@@ -272,6 +272,12 @@
         "state_attributes": {
           "events": {
             "name": "Ereignisse"
+          },
+          "pet_photos": {
+            "name": "Tierfotos"
+          },
+          "device_photos": {
+            "name": "Gerätefotos"
           }
         }
       },

--- a/custom_components/surepcha/translations/en.json
+++ b/custom_components/surepcha/translations/en.json
@@ -273,6 +273,12 @@
         "state_attributes": {
           "events": {
             "name": "Events"
+          },
+          "pet_photos": {
+            "name": "Pet photos"
+          },
+          "device_photos": {
+            "name": "Device photos"
           }
         }
       },

--- a/custom_components/surepcha/translations/sv.json
+++ b/custom_components/surepcha/translations/sv.json
@@ -272,6 +272,12 @@
         "state_attributes": {
           "events": {
             "name": "Händelser"
+          },
+          "pet_photos": {
+            "name": "Husdjursfoton"
+          },
+          "device_photos": {
+            "name": "Enhetsfoton"
           }
         }
       },

--- a/custom_components/surepcha/translations/sv.json
+++ b/custom_components/surepcha/translations/sv.json
@@ -239,6 +239,42 @@
           }
         }
       },
+      "feedings_today": {
+        "name": "Utfodringar idag",
+        "state_attributes": {
+          "total_grams": {
+            "name": "Gram totalt"
+          },
+          "events": {
+            "name": "Händelser"
+          }
+        }
+      },
+      "food_today": {
+        "name": "Mat idag",
+        "state_attributes": {
+          "count": {
+            "name": "Antal"
+          },
+          "total_wet_grams": {
+            "name": "Blötfoder totalt"
+          },
+          "total_dry_grams": {
+            "name": "Torrfoder totalt"
+          },
+          "events": {
+            "name": "Händelser"
+          }
+        }
+      },
+      "household_activity_today": {
+        "name": "Hushållsaktivitet idag",
+        "state_attributes": {
+          "events": {
+            "name": "Händelser"
+          }
+        }
+      },
       "position": {
         "name": "Position",
         "state": {

--- a/scripts/dump_timeline.py
+++ b/scripts/dump_timeline.py
@@ -1,0 +1,101 @@
+"""Diagnostic script: log in to Sure Petcare and dump household timeline + pet
+status data so we can inspect the real shape of feeding events.
+
+Credentials are entered interactively (password via getpass) and are never
+written to disk. Run with:
+
+    uv run python scripts/dump_timeline.py
+
+Output is written as JSON to the path given by --output.
+"""
+
+import argparse
+import asyncio
+import getpass
+import json
+from pathlib import Path
+
+from surepcio.client import SurePetcareClient
+from surepcio.household import Household
+
+
+async def main(pages: int, output: Path) -> None:
+    email = input("Sure Petcare email: ").strip()
+    password = getpass.getpass("Sure Petcare password: ")
+
+    client = SurePetcareClient()
+    try:
+        await client.login(email=email, password=password)
+
+        households = await client.api(Household.get_households())
+        if not households:
+            print("No households found for this account.")
+            return
+
+        household = households[0]
+        print(f"Using household id={household.id}")
+
+        pets = await client.api(household.get_pets())
+        print(f"Found {len(pets)} pet(s): {[p.name for p in pets]}")
+
+        timeline_events = []
+        before_id = None
+        for page in range(pages):
+            batch = await client.api(household.get_timeline(before_id=before_id))
+            if not batch:
+                break
+            timeline_events.extend(batch)
+            ids = [item["id"] for item in batch if "id" in item]
+            if not ids:
+                break
+            before_id = min(ids)
+            print(
+                f"Page {page + 1}: {len(batch)} events (oldest id so far: {before_id})"
+            )
+
+        dump = {
+            "household_id": household.id,
+            "pets": [
+                {
+                    "id": pet.id,
+                    "name": pet.name,
+                    "status": pet.status.model_dump(mode="json"),
+                }
+                for pet in pets
+            ],
+            "timeline_events": timeline_events,
+        }
+
+        output.write_text(json.dumps(dump, indent=2, default=str))
+        print(
+            f"\nWrote {len(timeline_events)} timeline events + pet status to {output}"
+        )
+
+        if timeline_events:
+            type_counts: dict = {}
+            for event in timeline_events:
+                key = event.get("type", "?")
+                type_counts[key] = type_counts.get(key, 0) + 1
+            print(f"Event type counts: {type_counts}")
+            print("\nSample event:")
+            print(json.dumps(timeline_events[0], indent=2, default=str))
+    finally:
+        await client.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--pages",
+        type=int,
+        default=3,
+        help="Number of timeline pages to fetch, paged backwards via before_id",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("timeline_dump.json"),
+        help="Where to write the JSON dump",
+    )
+    args = parser.parse_args()
+    asyncio.run(main(args.pages, args.output))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -15,6 +15,8 @@ PET_MOCKS = [
     "pet",
 ]
 
+TEST_HOUSEHOLD_ID = 222527
+
 
 async def initialize_entry(
     hass: HomeAssistant,
@@ -33,6 +35,7 @@ async def initialize_entry(
         """Return different data based on cmd.endpoint."""
         if hasattr(cmd, "endpoint") and "household" in cmd.endpoint:
             household = MagicMock()
+            household.id = TEST_HOUSEHOLD_ID
             household.get_devices.return_value = mock_devices
             household.get_pets.return_value = mock_pets
             return [household]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import pytest
 from custom_components.surepcha.const import (
     CLIENT_DEVICE_ID,
     DOMAIN,
+    HOUSEHOLD_ID,
+    HOUSEHOLD_SUBENTRY_TYPE,
     LOCATION_INSIDE,
     LOCATION_OUTSIDE,
     MANUAL_PROPERTIES,
@@ -13,7 +15,8 @@ from custom_components.surepcha.const import (
     PRODUCT_ID,
     TOKEN,
 )
-from . import DEVICE_MOCKS, PET_MOCKS
+from . import DEVICE_MOCKS, PET_MOCKS, TEST_HOUSEHOLD_ID
+from custom_components.surepcha.timeline import HouseholdTimelineData
 from surepcio import SurePetcareClient
 from surepcio.enums import ProductId
 from surepcio.devices.device import DeviceBase, PetBase
@@ -60,9 +63,18 @@ def mock_coordinator_update_data():
         # Return the current status/control or whatever your entities expect
         return self._device
 
-    with patch(
-        "custom_components.surepcha.coordinator.SurePetCareDeviceDataUpdateCoordinator._async_update_data",
-        new=return_device_data,
+    async def return_empty_timeline(self):
+        return HouseholdTimelineData()
+
+    with (
+        patch(
+            "custom_components.surepcha.coordinator.SurePetCareDeviceDataUpdateCoordinator._async_update_data",
+            new=return_device_data,
+        ),
+        patch(
+            "custom_components.surepcha.coordinator.SurePetCareTimelineCoordinator._async_update_data",
+            new=return_empty_timeline,
+        ),
     ):
         yield
 
@@ -148,6 +160,16 @@ def mock_config_entry() -> MockConfigEntry:
                 }
             },
         },
+        subentries_data=(
+            {
+                "data": {HOUSEHOLD_ID: TEST_HOUSEHOLD_ID},
+                "subentry_id": "test_household_subentry",
+                "subentry_type": HOUSEHOLD_SUBENTRY_TYPE,
+                "title": f"Household {TEST_HOUSEHOLD_ID}",
+                "unique_id": str(TEST_HOUSEHOLD_ID),
+            },
+        ),
+        minor_version=4,
         unique_id="12345",
     )
 
@@ -159,7 +181,17 @@ def mock_config_entry_missing_entities() -> MockConfigEntry:
         title="Test SurePetCare entry",
         domain=DOMAIN,
         data={TOKEN: "abc", CLIENT_DEVICE_ID: "123"},
-        options={OPTION_DEVICES: {}},
+        options={OPTION_DEVICES: {}, OPTION_PROPERTIES: {}},
+        subentries_data=(
+            {
+                "data": {HOUSEHOLD_ID: TEST_HOUSEHOLD_ID},
+                "subentry_id": "test_household_subentry",
+                "subentry_type": HOUSEHOLD_SUBENTRY_TYPE,
+                "title": f"Household {TEST_HOUSEHOLD_ID}",
+                "unique_id": str(TEST_HOUSEHOLD_ID),
+            },
+        ),
+        minor_version=4,
         unique_id="12345",
     )
 
@@ -238,6 +270,8 @@ async def mock_surepetcare_login_control(
             """Return different data based on cmd.endpoint."""
             if hasattr(cmd, "endpoint") and "household" in cmd.endpoint:
                 household = MagicMock()
+                household.id = TEST_HOUSEHOLD_ID
+                household.data = {}
                 household.get_devices.return_value = mock_devices
                 household.get_pets.return_value = mock_pets
                 return [household]

--- a/tests/snapshots/test_config_flow.ambr
+++ b/tests/snapshots/test_config_flow.ambr
@@ -10,7 +10,7 @@
     }),
     'domain': 'surepcha',
     'entry_id': <ANY>,
-    'minor_version': 2,
+    'minor_version': 4,
     'options': dict({
       'devices': dict({
         '12345': dict({
@@ -83,7 +83,7 @@
     }),
     'domain': 'surepcha',
     'entry_id': <ANY>,
-    'minor_version': 1,
+    'minor_version': 4,
     'options': dict({
       'devices': dict({
         '1299453': dict({
@@ -112,6 +112,15 @@
     'pref_disable_polling': False,
     'source': 'user',
     'subentries': list([
+      dict({
+        'data': dict({
+          'household_id': 222527,
+        }),
+        'subentry_id': 'test_household_subentry',
+        'subentry_type': 'household',
+        'title': 'Household 222527',
+        'unique_id': '222527',
+      }),
     ]),
     'title': 'Test SurePetCare entry',
     'unique_id': '12345',
@@ -129,7 +138,7 @@
     }),
     'domain': 'surepcha',
     'entry_id': <ANY>,
-    'minor_version': 1,
+    'minor_version': 4,
     'options': dict({
       'devices': dict({
         '1299453': dict({
@@ -188,6 +197,15 @@
     'pref_disable_polling': False,
     'source': 'user',
     'subentries': list([
+      dict({
+        'data': dict({
+          'household_id': 222527,
+        }),
+        'subentry_id': 'test_household_subentry',
+        'subentry_type': 'household',
+        'title': 'Household 222527',
+        'unique_id': '222527',
+      }),
     ]),
     'title': 'Test SurePetCare entry',
     'unique_id': '12345',
@@ -207,7 +225,7 @@
     'description_placeholders': None,
     'flow_id': <ANY>,
     'handler': 'surepcha',
-    'minor_version': 3,
+    'minor_version': 4,
     'options': dict({
       'devices': dict({
         '1299453': dict({
@@ -268,7 +286,7 @@
       }),
       'domain': 'surepcha',
       'entry_id': <ANY>,
-      'minor_version': 3,
+      'minor_version': 4,
       'options': dict({
         'devices': dict({
           '1299453': dict({
@@ -323,13 +341,29 @@
       'pref_disable_polling': False,
       'source': 'user',
       'subentries': list([
+        dict({
+          'data': dict({
+            'household_id': 222527,
+          }),
+          'subentry_type': 'household',
+          'title': 'Household 222527',
+          'unique_id': '222527',
+        }),
       ]),
       'title': 'SurePetCare Devices',
       'unique_id': None,
       'version': 1,
     }),
-    'subentries': tuple(
-    ),
+    'subentries': list([
+      dict({
+        'data': dict({
+          'household_id': 222527,
+        }),
+        'subentry_type': 'household',
+        'title': 'Household 222527',
+        'unique_id': '222527',
+      }),
+    ]),
     'title': 'SurePetCare Devices',
     'type': <FlowResultType.CREATE_ENTRY: 'create_entry'>,
     'version': 1,

--- a/tests/snapshots/test_diagnostics.ambr
+++ b/tests/snapshots/test_diagnostics.ambr
@@ -108,6 +108,10 @@
         }),
       }),
       'properties': dict({
+        'manual_properties': dict({
+          'location_inside': 'Home',
+          'location_outside': 'Away',
+        }),
       }),
     }),
   })
@@ -136,6 +140,10 @@
         }),
       }),
       'properties': dict({
+        'manual_properties': dict({
+          'location_inside': 'Home',
+          'location_outside': 'Away',
+        }),
       }),
     }),
   })

--- a/tests/snapshots/test_init.ambr
+++ b/tests/snapshots/test_init.ambr
@@ -340,3 +340,65 @@
     'via_device_id': None,
   })
 # ---
+# name: test_device_registry[household-222527]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'surepcha',
+        'household-222527',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'SurePetCare',
+    'model': 'Household',
+    'model_id': None,
+    'name': 'Household 222527',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
+# name: test_device_registry[household-245684]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'surepcha',
+        'household-245684',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'SurePetCare',
+    'model': 'Household',
+    'model_id': None,
+    'name': 'Household 245684',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---

--- a/tests/snapshots/test_sensor.ambr
+++ b/tests/snapshots/test_sensor.ambr
@@ -230,6 +230,128 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_platform_setup_and_discovery[sensor.ajax_feedings_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ajax_feedings_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Feedings Today',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:counter',
+    'original_name': 'Feedings Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'feedings_today',
+    'unique_id': '532070-feedings_today',
+    'unit_of_measurement': 'feedings',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.ajax_feedings_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'events': list([
+      ]),
+      'friendly_name': 'Ajax Feedings Today',
+      'icon': 'mdi:counter',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'total_grams': 0.0,
+      'unit_of_measurement': 'feedings',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ajax_feedings_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.ajax_food_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ajax_food_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Food Today',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WEIGHT: 'weight'>,
+    'original_icon': 'mdi:food-drumstick',
+    'original_name': 'Food Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'food_today',
+    'unique_id': '532070-food_today',
+    'unit_of_measurement': <UnitOfMass.GRAMS: 'g'>,
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.ajax_food_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'count': 0,
+      'device_class': 'weight',
+      'events': list([
+      ]),
+      'friendly_name': 'Ajax Food Today',
+      'icon': 'mdi:food-drumstick',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'total_dry_grams': 0.0,
+      'total_wet_grams': 0.0,
+      'unit_of_measurement': <UnitOfMass.GRAMS: 'g'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ajax_food_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
 # name: test_platform_setup_and_discovery[sensor.ajax_last_activity-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -853,6 +975,120 @@
     'state': '149.0',
   })
 # ---
+# name: test_platform_setup_and_discovery[sensor.household_222527_household_activity_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.household_222527_household_activity_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Household Activity Today',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:timeline-clock-outline',
+    'original_name': 'Household Activity Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'household_activity_today',
+    'unique_id': 'household-222527-activity_today',
+    'unit_of_measurement': 'events',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.household_222527_household_activity_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'events': list([
+      ]),
+      'friendly_name': 'Household 222527 Household Activity Today',
+      'icon': 'mdi:timeline-clock-outline',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': 'events',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.household_222527_household_activity_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.household_245684_household_activity_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.household_245684_household_activity_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Household Activity Today',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:timeline-clock-outline',
+    'original_name': 'Household Activity Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'household_activity_today',
+    'unique_id': 'household-245684-activity_today',
+    'unit_of_measurement': 'events',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.household_245684_household_activity_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'events': list([
+      ]),
+      'friendly_name': 'Household 245684 Household Activity Today',
+      'icon': 'mdi:timeline-clock-outline',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': 'events',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.household_245684_household_activity_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
 # name: test_platform_setup_and_discovery[sensor.katzenklappe_battery-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -1421,6 +1657,128 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '5.23',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.maui_feedings_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.maui_feedings_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Feedings Today',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:counter',
+    'original_name': 'Feedings Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'feedings_today',
+    'unique_id': '472721-feedings_today',
+    'unit_of_measurement': 'feedings',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.maui_feedings_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'events': list([
+      ]),
+      'friendly_name': 'Maui Feedings Today',
+      'icon': 'mdi:counter',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'total_grams': 0.0,
+      'unit_of_measurement': 'feedings',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.maui_feedings_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.maui_food_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.maui_food_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Food Today',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WEIGHT: 'weight'>,
+    'original_icon': 'mdi:food-drumstick',
+    'original_name': 'Food Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'food_today',
+    'unique_id': '472721-food_today',
+    'unit_of_measurement': <UnitOfMass.GRAMS: 'g'>,
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.maui_food_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'count': 0,
+      'device_class': 'weight',
+      'events': list([
+      ]),
+      'friendly_name': 'Maui Food Today',
+      'icon': 'mdi:food-drumstick',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'total_dry_grams': 0.0,
+      'total_wet_grams': 0.0,
+      'unit_of_measurement': <UnitOfMass.GRAMS: 'g'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.maui_food_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
   })
 # ---
 # name: test_platform_setup_and_discovery[sensor.maui_last_activity-entry]
@@ -2171,6 +2529,128 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_platform_setup_and_discovery[sensor.pet_with_empty_status_feedings_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pet_with_empty_status_feedings_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Feedings Today',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:counter',
+    'original_name': 'Feedings Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'feedings_today',
+    'unique_id': '222222-feedings_today',
+    'unit_of_measurement': 'feedings',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.pet_with_empty_status_feedings_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'events': list([
+      ]),
+      'friendly_name': 'Pet with empty status Feedings Today',
+      'icon': 'mdi:counter',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'total_grams': 0.0,
+      'unit_of_measurement': 'feedings',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pet_with_empty_status_feedings_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.pet_with_empty_status_food_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pet_with_empty_status_food_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Food Today',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WEIGHT: 'weight'>,
+    'original_icon': 'mdi:food-drumstick',
+    'original_name': 'Food Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'food_today',
+    'unique_id': '222222-food_today',
+    'unit_of_measurement': <UnitOfMass.GRAMS: 'g'>,
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.pet_with_empty_status_food_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'count': 0,
+      'device_class': 'weight',
+      'events': list([
+      ]),
+      'friendly_name': 'Pet with empty status Food Today',
+      'icon': 'mdi:food-drumstick',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'total_dry_grams': 0.0,
+      'total_wet_grams': 0.0,
+      'unit_of_measurement': <UnitOfMass.GRAMS: 'g'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pet_with_empty_status_food_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
 # name: test_platform_setup_and_discovery[sensor.pet_with_empty_status_last_activity-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -2513,6 +2993,128 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '4.23',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.pet_with_only_one_change_on_status_feedings_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pet_with_only_one_change_on_status_feedings_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Feedings Today',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:counter',
+    'original_name': 'Feedings Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'feedings_today',
+    'unique_id': '333333-feedings_today',
+    'unit_of_measurement': 'feedings',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.pet_with_only_one_change_on_status_feedings_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'events': list([
+      ]),
+      'friendly_name': 'Pet with only one change on status Feedings Today',
+      'icon': 'mdi:counter',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'total_grams': 0.0,
+      'unit_of_measurement': 'feedings',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pet_with_only_one_change_on_status_feedings_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.pet_with_only_one_change_on_status_food_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pet_with_only_one_change_on_status_food_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Food Today',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WEIGHT: 'weight'>,
+    'original_icon': 'mdi:food-drumstick',
+    'original_name': 'Food Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'food_today',
+    'unique_id': '333333-food_today',
+    'unit_of_measurement': <UnitOfMass.GRAMS: 'g'>,
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.pet_with_only_one_change_on_status_food_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'count': 0,
+      'device_class': 'weight',
+      'events': list([
+      ]),
+      'friendly_name': 'Pet with only one change on status Food Today',
+      'icon': 'mdi:food-drumstick',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'total_dry_grams': 0.0,
+      'total_wet_grams': 0.0,
+      'unit_of_measurement': <UnitOfMass.GRAMS: 'g'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pet_with_only_one_change_on_status_food_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
   })
 # ---
 # name: test_platform_setup_and_discovery[sensor.pet_with_only_one_change_on_status_last_activity-entry]
@@ -3275,6 +3877,128 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.ajax_feedings_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ajax_feedings_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Feedings Today',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:counter',
+    'original_name': 'Feedings Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'feedings_today',
+    'unique_id': '532070-feedings_today',
+    'unit_of_measurement': 'feedings',
+  })
+# ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.ajax_feedings_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'events': list([
+      ]),
+      'friendly_name': 'Ajax Feedings Today',
+      'icon': 'mdi:counter',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'total_grams': 0.0,
+      'unit_of_measurement': 'feedings',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ajax_feedings_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.ajax_food_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ajax_food_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Food Today',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WEIGHT: 'weight'>,
+    'original_icon': 'mdi:food-drumstick',
+    'original_name': 'Food Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'food_today',
+    'unique_id': '532070-food_today',
+    'unit_of_measurement': <UnitOfMass.GRAMS: 'g'>,
+  })
+# ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.ajax_food_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'count': 0,
+      'device_class': 'weight',
+      'events': list([
+      ]),
+      'friendly_name': 'Ajax Food Today',
+      'icon': 'mdi:food-drumstick',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'total_dry_grams': 0.0,
+      'total_wet_grams': 0.0,
+      'unit_of_measurement': <UnitOfMass.GRAMS: 'g'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ajax_food_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
 # name: test_platform_setup_and_discovery_missing_entities[sensor.ajax_last_activity-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -3898,6 +4622,120 @@
     'state': '149.0',
   })
 # ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.household_222527_household_activity_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.household_222527_household_activity_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Household Activity Today',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:timeline-clock-outline',
+    'original_name': 'Household Activity Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'household_activity_today',
+    'unique_id': 'household-222527-activity_today',
+    'unit_of_measurement': 'events',
+  })
+# ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.household_222527_household_activity_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'events': list([
+      ]),
+      'friendly_name': 'Household 222527 Household Activity Today',
+      'icon': 'mdi:timeline-clock-outline',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': 'events',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.household_222527_household_activity_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.household_245684_household_activity_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.household_245684_household_activity_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Household Activity Today',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:timeline-clock-outline',
+    'original_name': 'Household Activity Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'household_activity_today',
+    'unique_id': 'household-245684-activity_today',
+    'unit_of_measurement': 'events',
+  })
+# ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.household_245684_household_activity_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'events': list([
+      ]),
+      'friendly_name': 'Household 245684 Household Activity Today',
+      'icon': 'mdi:timeline-clock-outline',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'unit_of_measurement': 'events',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.household_245684_household_activity_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
 # name: test_platform_setup_and_discovery_missing_entities[sensor.katzenklappe_battery-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -4466,6 +5304,128 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '5.23',
+  })
+# ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.maui_feedings_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.maui_feedings_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Feedings Today',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:counter',
+    'original_name': 'Feedings Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'feedings_today',
+    'unique_id': '472721-feedings_today',
+    'unit_of_measurement': 'feedings',
+  })
+# ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.maui_feedings_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'events': list([
+      ]),
+      'friendly_name': 'Maui Feedings Today',
+      'icon': 'mdi:counter',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'total_grams': 0.0,
+      'unit_of_measurement': 'feedings',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.maui_feedings_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.maui_food_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.maui_food_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Food Today',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WEIGHT: 'weight'>,
+    'original_icon': 'mdi:food-drumstick',
+    'original_name': 'Food Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'food_today',
+    'unique_id': '472721-food_today',
+    'unit_of_measurement': <UnitOfMass.GRAMS: 'g'>,
+  })
+# ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.maui_food_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'count': 0,
+      'device_class': 'weight',
+      'events': list([
+      ]),
+      'friendly_name': 'Maui Food Today',
+      'icon': 'mdi:food-drumstick',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'total_dry_grams': 0.0,
+      'total_wet_grams': 0.0,
+      'unit_of_measurement': <UnitOfMass.GRAMS: 'g'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.maui_food_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
   })
 # ---
 # name: test_platform_setup_and_discovery_missing_entities[sensor.maui_last_activity-entry]
@@ -5215,6 +6175,128 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.pet_with_empty_status_feedings_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pet_with_empty_status_feedings_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Feedings Today',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:counter',
+    'original_name': 'Feedings Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'feedings_today',
+    'unique_id': '222222-feedings_today',
+    'unit_of_measurement': 'feedings',
+  })
+# ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.pet_with_empty_status_feedings_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'events': list([
+      ]),
+      'friendly_name': 'Pet with empty status Feedings Today',
+      'icon': 'mdi:counter',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'total_grams': 0.0,
+      'unit_of_measurement': 'feedings',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pet_with_empty_status_feedings_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.pet_with_empty_status_food_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pet_with_empty_status_food_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Food Today',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WEIGHT: 'weight'>,
+    'original_icon': 'mdi:food-drumstick',
+    'original_name': 'Food Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'food_today',
+    'unique_id': '222222-food_today',
+    'unit_of_measurement': <UnitOfMass.GRAMS: 'g'>,
+  })
+# ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.pet_with_empty_status_food_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'count': 0,
+      'device_class': 'weight',
+      'events': list([
+      ]),
+      'friendly_name': 'Pet with empty status Food Today',
+      'icon': 'mdi:food-drumstick',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'total_dry_grams': 0.0,
+      'total_wet_grams': 0.0,
+      'unit_of_measurement': <UnitOfMass.GRAMS: 'g'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pet_with_empty_status_food_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
 # name: test_platform_setup_and_discovery_missing_entities[sensor.pet_with_empty_status_last_activity-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -5557,6 +6639,128 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '4.23',
+  })
+# ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.pet_with_only_one_change_on_status_feedings_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pet_with_only_one_change_on_status_feedings_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Feedings Today',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:counter',
+    'original_name': 'Feedings Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'feedings_today',
+    'unique_id': '333333-feedings_today',
+    'unit_of_measurement': 'feedings',
+  })
+# ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.pet_with_only_one_change_on_status_feedings_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'events': list([
+      ]),
+      'friendly_name': 'Pet with only one change on status Feedings Today',
+      'icon': 'mdi:counter',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'total_grams': 0.0,
+      'unit_of_measurement': 'feedings',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pet_with_only_one_change_on_status_feedings_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.pet_with_only_one_change_on_status_food_today-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.pet_with_only_one_change_on_status_food_today',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Food Today',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WEIGHT: 'weight'>,
+    'original_icon': 'mdi:food-drumstick',
+    'original_name': 'Food Today',
+    'platform': 'surepcha',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'food_today',
+    'unique_id': '333333-food_today',
+    'unit_of_measurement': <UnitOfMass.GRAMS: 'g'>,
+  })
+# ---
+# name: test_platform_setup_and_discovery_missing_entities[sensor.pet_with_only_one_change_on_status_food_today-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'count': 0,
+      'device_class': 'weight',
+      'events': list([
+      ]),
+      'friendly_name': 'Pet with only one change on status Food Today',
+      'icon': 'mdi:food-drumstick',
+      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'total_dry_grams': 0.0,
+      'total_wet_grams': 0.0,
+      'unit_of_measurement': <UnitOfMass.GRAMS: 'g'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.pet_with_only_one_change_on_status_food_today',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
   })
 # ---
 # name: test_platform_setup_and_discovery_missing_entities[sensor.pet_with_only_one_change_on_status_last_activity-entry]

--- a/tests/snapshots/test_sensor.ambr
+++ b/tests/snapshots/test_sensor.ambr
@@ -981,9 +981,7 @@
       None,
     ]),
     'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-    }),
+    'capabilities': None,
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
     'device_class': None,
@@ -1017,11 +1015,25 @@
 # name: test_platform_setup_and_discovery[sensor.household_222527_household_activity_today-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_photos': dict({
+        '22222': 'https://www.surepetcare.io/assets/assets/products/feeder.7ff330c9e368df01d256156b6fc797bb.png',
+        '222222': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '269654': 'https://www.surepetcare.io/assets/assets/products/feeder.7ff330c9e368df01d256156b6fc797bb.png',
+        '295972': 'https://www.surepetcare.io/assets/assets/products/hub/hub.6475b3a385180ab8fb96731c4bfd1eda.png',
+        '333333': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '472721': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '532070': 'https://userimages.production.surehub.io/thm/3139226750/8YflEvJWEcbrcPrfn1ztq53inPl4xPNJms1pFi84wU.jpg',
+      }),
       'events': list([
       ]),
       'friendly_name': 'Household 222527 Household Activity Today',
       'icon': 'mdi:timeline-clock-outline',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'pet_photos': dict({
+        '222222': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '333333': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '472721': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '532070': 'https://userimages.production.surehub.io/thm/3139226750/8YflEvJWEcbrcPrfn1ztq53inPl4xPNJms1pFi84wU.jpg',
+      }),
       'unit_of_measurement': 'events',
     }),
     'context': <ANY>,
@@ -1038,9 +1050,7 @@
       None,
     ]),
     'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-    }),
+    'capabilities': None,
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
     'device_class': None,
@@ -1074,11 +1084,25 @@
 # name: test_platform_setup_and_discovery[sensor.household_245684_household_activity_today-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_photos': dict({
+        '22222': 'https://www.surepetcare.io/assets/assets/products/feeder.7ff330c9e368df01d256156b6fc797bb.png',
+        '222222': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '269654': 'https://www.surepetcare.io/assets/assets/products/feeder.7ff330c9e368df01d256156b6fc797bb.png',
+        '295972': 'https://www.surepetcare.io/assets/assets/products/hub/hub.6475b3a385180ab8fb96731c4bfd1eda.png',
+        '333333': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '472721': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '532070': 'https://userimages.production.surehub.io/thm/3139226750/8YflEvJWEcbrcPrfn1ztq53inPl4xPNJms1pFi84wU.jpg',
+      }),
       'events': list([
       ]),
       'friendly_name': 'Household 245684 Household Activity Today',
       'icon': 'mdi:timeline-clock-outline',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'pet_photos': dict({
+        '222222': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '333333': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '472721': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '532070': 'https://userimages.production.surehub.io/thm/3139226750/8YflEvJWEcbrcPrfn1ztq53inPl4xPNJms1pFi84wU.jpg',
+      }),
       'unit_of_measurement': 'events',
     }),
     'context': <ANY>,
@@ -4628,9 +4652,7 @@
       None,
     ]),
     'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-    }),
+    'capabilities': None,
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
     'device_class': None,
@@ -4664,11 +4686,25 @@
 # name: test_platform_setup_and_discovery_missing_entities[sensor.household_222527_household_activity_today-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_photos': dict({
+        '22222': 'https://www.surepetcare.io/assets/assets/products/feeder.7ff330c9e368df01d256156b6fc797bb.png',
+        '222222': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '269654': 'https://www.surepetcare.io/assets/assets/products/feeder.7ff330c9e368df01d256156b6fc797bb.png',
+        '295972': 'https://www.surepetcare.io/assets/assets/products/hub/hub.6475b3a385180ab8fb96731c4bfd1eda.png',
+        '333333': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '472721': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '532070': 'https://userimages.production.surehub.io/thm/3139226750/8YflEvJWEcbrcPrfn1ztq53inPl4xPNJms1pFi84wU.jpg',
+      }),
       'events': list([
       ]),
       'friendly_name': 'Household 222527 Household Activity Today',
       'icon': 'mdi:timeline-clock-outline',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'pet_photos': dict({
+        '222222': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '333333': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '472721': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '532070': 'https://userimages.production.surehub.io/thm/3139226750/8YflEvJWEcbrcPrfn1ztq53inPl4xPNJms1pFi84wU.jpg',
+      }),
       'unit_of_measurement': 'events',
     }),
     'context': <ANY>,
@@ -4685,9 +4721,7 @@
       None,
     ]),
     'area_id': None,
-    'capabilities': dict({
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-    }),
+    'capabilities': None,
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
     'device_class': None,
@@ -4721,11 +4755,25 @@
 # name: test_platform_setup_and_discovery_missing_entities[sensor.household_245684_household_activity_today-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
+      'device_photos': dict({
+        '22222': 'https://www.surepetcare.io/assets/assets/products/feeder.7ff330c9e368df01d256156b6fc797bb.png',
+        '222222': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '269654': 'https://www.surepetcare.io/assets/assets/products/feeder.7ff330c9e368df01d256156b6fc797bb.png',
+        '295972': 'https://www.surepetcare.io/assets/assets/products/hub/hub.6475b3a385180ab8fb96731c4bfd1eda.png',
+        '333333': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '472721': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '532070': 'https://userimages.production.surehub.io/thm/3139226750/8YflEvJWEcbrcPrfn1ztq53inPl4xPNJms1pFi84wU.jpg',
+      }),
       'events': list([
       ]),
       'friendly_name': 'Household 245684 Household Activity Today',
       'icon': 'mdi:timeline-clock-outline',
-      'state_class': <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      'pet_photos': dict({
+        '222222': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '333333': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '472721': 'https://userimages.production.surehub.io/thm/3139194472/UCcarrDHzX0MkjEORQqCXNLKxsdweCQPJjl3OQ7s.jpg',
+        '532070': 'https://userimages.production.surehub.io/thm/3139226750/8YflEvJWEcbrcPrfn1ztq53inPl4xPNJms1pFi84wU.jpg',
+      }),
       'unit_of_measurement': 'events',
     }),
     'context': <ANY>,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,5 +1,6 @@
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from syrupy.filters import props
 from homeassistant.core import HomeAssistant
 
 from custom_components.surepcha import async_migrate_entry
@@ -13,6 +14,7 @@ from custom_components.surepcha.const import (
     CONF_EMAIL,
     CONF_PASSWORD,
     ENTRY_ID,
+    HOUSEHOLD_SUBENTRY_TYPE,
     LOCATION_INSIDE,
     LOCATION_OUTSIDE,
     MANUAL_PROPERTIES,
@@ -30,7 +32,8 @@ from custom_components.surepcha.config_flow import (
 )
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from unittest.mock import patch
+from . import TEST_HOUSEHOLD_ID
+from unittest.mock import AsyncMock, MagicMock, patch
 from homeassistant.data_entry_flow import FlowResultType
 from surepcio import Household
 
@@ -175,7 +178,138 @@ async def test_user_flow(
 
     assert result2.get("type") is FlowResultType.CREATE_ENTRY
 
-    assert result2 == snapshot
+    # subentry_id is a freshly generated ULID on every real login, so it can't
+    # be snapshotted verbatim - everything else about the created entry can.
+    assert result2 == snapshot(exclude=props("subentry_id"))
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_user_flow_creates_one_subentry_per_household_with_devices(
+    hass: HomeAssistant, mock_pets, mock_devices
+) -> None:
+    """Households with devices become subentries; empty households are skipped."""
+    with (
+        patch(
+            "custom_components.surepcha.config_flow.SurePetcareClient", autospec=True
+        ) as client_mock,
+        patch(
+            "custom_components.surepcha.SurePetcareClient", autospec=True
+        ) as setup_mock,
+    ):
+        instance = client_mock.return_value
+        setup_mock.return_value = instance
+        instance.login = AsyncMock(return_value=True)
+        instance.token = "mocked_token"
+        instance.device_id = "mocked_device_id"
+
+        def api_side_effect(cmd):
+            if hasattr(cmd, "endpoint") and "household" in cmd.endpoint:
+                household_a = MagicMock()
+                household_a.id = 111
+                household_a.data = {"name": "Storm"}
+                household_a.get_devices.return_value = mock_devices
+                household_a.get_pets.return_value = mock_pets
+                household_b = MagicMock()
+                household_b.id = 222
+                household_b.data = {"name": "Empty Household"}
+                household_b.get_devices.return_value = []
+                household_b.get_pets.return_value = []
+                return [household_a, household_b]
+            return cmd
+
+        instance.api = AsyncMock(side_effect=api_side_effect)
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "user"}
+        )
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_EMAIL: "test@example.com", CONF_PASSWORD: "password123"},
+        )
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    subentries = list(result2["subentries"])
+    assert len(subentries) == 1
+    assert subentries[0]["title"] == "Storm"
+    assert subentries[0]["unique_id"] == "111"
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_household_subentry_flow_adds_new_household(
+    hass: HomeAssistant, mock_config_entry, mock_pets, mock_devices
+) -> None:
+    """A household added after initial setup can be added as a subentry, no re-login needed."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.surepcha.config_flow.SurePetcareClient", autospec=True
+    ) as client_mock:
+        instance = client_mock.return_value
+        instance.login = AsyncMock(return_value=True)
+        instance.token = "mocked_token"
+        instance.device_id = "mocked_device_id"
+
+        def api_side_effect(cmd):
+            if hasattr(cmd, "endpoint") and "household" in cmd.endpoint:
+                existing = MagicMock()
+                existing.id = TEST_HOUSEHOLD_ID
+                existing.data = {"name": "Storm"}
+                existing.get_devices.return_value = mock_devices
+                existing.get_pets.return_value = mock_pets
+                new_household = MagicMock()
+                new_household.id = 999
+                new_household.data = {"name": "Second Home"}
+                new_household.get_devices.return_value = mock_devices
+                new_household.get_pets.return_value = mock_pets
+                return [existing, new_household]
+            return cmd
+
+        instance.api = AsyncMock(side_effect=api_side_effect)
+
+        result = await hass.config_entries.subentries.async_init(
+            (mock_config_entry.entry_id, HOUSEHOLD_SUBENTRY_TYPE),
+            context={"source": "user"},
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Second Home"
+    assert result["unique_id"] == "999"
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_household_subentry_flow_aborts_when_no_new_household(
+    hass: HomeAssistant, mock_config_entry, mock_pets, mock_devices
+) -> None:
+    """Nothing to add if every household with devices is already a subentry."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.surepcha.config_flow.SurePetcareClient", autospec=True
+    ) as client_mock:
+        instance = client_mock.return_value
+        instance.login = AsyncMock(return_value=True)
+        instance.token = "mocked_token"
+        instance.device_id = "mocked_device_id"
+
+        def api_side_effect(cmd):
+            if hasattr(cmd, "endpoint") and "household" in cmd.endpoint:
+                existing = MagicMock()
+                existing.id = TEST_HOUSEHOLD_ID
+                existing.data = {"name": "Storm"}
+                existing.get_devices.return_value = mock_devices
+                existing.get_pets.return_value = mock_pets
+                return [existing]
+            return cmd
+
+        instance.api = AsyncMock(side_effect=api_side_effect)
+
+        result = await hass.config_entries.subentries.async_init(
+            (mock_config_entry.entry_id, HOUSEHOLD_SUBENTRY_TYPE),
+            context={"source": "user"},
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "no_new_household_found"
 
 
 @pytest.mark.usefixtures("mock_surepetcare_login_control", "enable_custom_integrations")
@@ -280,10 +414,22 @@ async def test_async_migrate_entry_adds_manual_properties(
     )
     entry.add_to_hass(hass)
 
-    migrated = await async_migrate_entry(hass, entry)
+    # The migration also fans households out into subentries (a separate step
+    # from the manual-properties migration this test focuses on) - mock the
+    # live fetch it performs so it completes without touching the network.
+    mock_client = MagicMock()
+    mock_client.login = AsyncMock(return_value=None)
+    mock_client.api = AsyncMock(return_value=[])
+    mock_client.close = AsyncMock(return_value=None)
+
+    with patch(
+        "custom_components.surepcha.SurePetcareClient", return_value=mock_client
+    ):
+        migrated = await async_migrate_entry(hass, entry)
+
     assert migrated
     assert MANUAL_PROPERTIES not in entry.options
-    assert entry.minor_version == 2
+    assert entry.minor_version == 4
     assert entry.version == 1
     assert OPTION_PROPERTIES in entry.options
     assert entry.options[OPTION_PROPERTIES][MANUAL_PROPERTIES] == {

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,8 +1,15 @@
 import importlib
 import inspect
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 import custom_components.surepcha.__init__ as surepetcare_init
-from custom_components.surepcha.const import CLIENT_DEVICE_ID, FACTORY, TOKEN
+from custom_components.surepcha.const import (
+    CLIENT_DEVICE_ID,
+    FACTORY,
+    HOUSEHOLD_ID,
+    OPTION_DEVICES,
+    OPTION_PROPERTIES,
+    TOKEN,
+)
 import pytest
 from custom_components.surepcha import remove_stale_devices, DOMAIN
 from surepcio.enums import ProductId
@@ -79,6 +86,13 @@ class DummyClient:
         pass
 
 
+class DummySubentry:
+    """A dummy config subentry for use in integration tests."""
+
+    def __init__(self, household_id):
+        self.data = {HOUSEHOLD_ID: household_id}
+
+
 class DummyConfigEntry:
     """A dummy config entry for use in integration tests."""
 
@@ -87,6 +101,7 @@ class DummyConfigEntry:
         self.domain = DOMAIN
         self.data = {TOKEN: "tok", CLIENT_DEVICE_ID: "dev"}
         self.options = {}
+        self.subentries = {"sub1": DummySubentry("dummy_household_id")}
         self.state = ConfigEntryState.SETUP_IN_PROGRESS
 
     def async_on_unload(self, _):
@@ -391,6 +406,46 @@ def test_remove_stale_devices_logic():
 
 
 @pytest.mark.usefixtures("enable_custom_integrations")
+async def test_setup_entry_heals_stale_no_subentry_device_association(
+    hass: HomeAssistant,
+    mock_client: SurePetcareClient,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    mock_devices: list[DeviceBase],
+    mock_pets: list[PetBase],
+) -> None:
+    """A device registered before subentries existed lives in the registry's
+    "no subentry" (None) bucket for its entry. Regression test for a real bug:
+    async_get_or_create's config_subentry_id only ever *adds* an association,
+    so a plain add left devices belonging to both None and the real subentry
+    at once - HA's UI then filed them under "no subentry". Setup must
+    explicitly drop the stale None association once a real one applies.
+    """
+    mock_config_entry.add_to_hass(hass)
+    # Pre-register the way setup used to, pre-subentries: entry only, no subentry.
+    device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, "269654")},
+        manufacturer="SurePetCare",
+        name="Maui matlåda (old)",
+    )
+    stale = device_registry.async_get_device(identifiers={(DOMAIN, "269654")})
+    assert stale is not None
+    assert stale.config_entries_subentries[mock_config_entry.entry_id] == {None}
+
+    await initialize_entry(
+        hass, mock_client, mock_config_entry, mock_devices, mock_pets
+    )
+
+    subentry = next(iter(mock_config_entry.subentries.values()))
+    healed = device_registry.async_get_device(identifiers={(DOMAIN, "269654")})
+    assert healed is not None
+    associated_subentries = healed.config_entries_subentries[mock_config_entry.entry_id]
+    assert associated_subentries == {subentry.subentry_id}
+    assert None not in associated_subentries
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
 async def test_device_registry(
     hass: HomeAssistant,
     mock_client: SurePetcareClient,
@@ -426,3 +481,186 @@ async def test_device_registry(
                 include_disabled_entities=True,
             )
         )
+
+
+def _mock_household(household_id: int, name: str, device_ids: list[int]) -> MagicMock:
+    """Build a MagicMock household reporting the given devices (no pets)."""
+    household = MagicMock()
+    household.id = household_id
+    household.data = {"name": name}
+    household.get_devices.return_value = [
+        MagicMock(id=device_id) for device_id in device_ids
+    ]
+    household.get_pets.return_value = []
+    return household
+
+
+def _mock_client_for_households(*households: MagicMock) -> MagicMock:
+    """Build a mock SurePetcareClient whose get_households() returns the given list."""
+    client = MagicMock()
+    client.login = AsyncMock(return_value=None)
+    client.close = AsyncMock(return_value=None)
+
+    def api_side_effect(cmd):
+        if hasattr(cmd, "endpoint") and "household" in cmd.endpoint:
+            return list(households)
+        return cmd
+
+    client.api = AsyncMock(side_effect=api_side_effect)
+    return client
+
+
+@pytest.mark.asyncio
+async def test_migrate_entry_adds_subentry_for_single_household(
+    hass: HomeAssistant,
+) -> None:
+    """A pre-subentries entry with one household gets a matching subentry, and its
+    already-registered device is tagged with it - config_entry_id never changes."""
+    entry = MockConfigEntry(
+        version=1,
+        minor_version=3,
+        title="Test SurePetCare entry",
+        domain=DOMAIN,
+        data={TOKEN: "abc", CLIENT_DEVICE_ID: "123"},
+        options={OPTION_DEVICES: {}, OPTION_PROPERTIES: {}},
+        unique_id="12345",
+    )
+    entry.add_to_hass(hass)
+
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "1001")},
+        manufacturer="SurePetCare",
+        name="Feeder",
+    )
+
+    household = _mock_household(555, "Storm", [1001])
+
+    with patch(
+        "custom_components.surepcha.__init__.SurePetcareClient",
+        return_value=_mock_client_for_households(household),
+    ):
+        migrated = await surepetcare_init.async_migrate_entry(hass, entry)
+
+    assert migrated
+    assert entry.minor_version == 4
+    assert len(entry.subentries) == 1
+    subentry = next(iter(entry.subentries.values()))
+    assert subentry.data[HOUSEHOLD_ID] == 555
+    assert subentry.title == "Storm"
+    assert subentry.unique_id == "555"
+
+    updated_device = device_registry.async_get_device(identifiers={(DOMAIN, "1001")})
+    assert updated_device.config_entries == {entry.entry_id}
+    assert (
+        subentry.subentry_id in updated_device.config_entries_subentries[entry.entry_id]
+    )
+
+
+@pytest.mark.asyncio
+async def test_migrate_entry_adds_subentry_per_household_for_multiple_households(
+    hass: HomeAssistant,
+) -> None:
+    """Matches a real multi-household account: each household-with-devices gets its
+    own subentry in a single migration pass."""
+    entry = MockConfigEntry(
+        version=1,
+        minor_version=3,
+        title="Test SurePetCare entry",
+        domain=DOMAIN,
+        data={TOKEN: "abc", CLIENT_DEVICE_ID: "123"},
+        options={OPTION_DEVICES: {}, OPTION_PROPERTIES: {}},
+        unique_id="12345",
+    )
+    entry.add_to_hass(hass)
+
+    household_a = _mock_household(111, "Storm", [2001])
+    household_b = _mock_household(222, "Second Home", [2002])
+    # A household with no devices/pets at all should not get a subentry.
+    household_c = _mock_household(333, "Empty Household", [])
+
+    with patch(
+        "custom_components.surepcha.__init__.SurePetcareClient",
+        return_value=_mock_client_for_households(household_a, household_b, household_c),
+    ):
+        migrated = await surepetcare_init.async_migrate_entry(hass, entry)
+
+    assert migrated
+    assert entry.minor_version == 4
+    household_ids = {
+        subentry.data[HOUSEHOLD_ID] for subentry in entry.subentries.values()
+    }
+    assert household_ids == {111, 222}
+
+
+@pytest.mark.asyncio
+async def test_migrate_entry_retries_on_fetch_failure(hass: HomeAssistant) -> None:
+    """A network failure during migration must not brick the entry - it should stay
+    unmigrated so Home Assistant retries on the next startup."""
+    entry = MockConfigEntry(
+        version=1,
+        minor_version=3,
+        title="Test SurePetCare entry",
+        domain=DOMAIN,
+        data={TOKEN: "abc", CLIENT_DEVICE_ID: "123"},
+        options={OPTION_DEVICES: {}, OPTION_PROPERTIES: {}},
+        unique_id="12345",
+    )
+    entry.add_to_hass(hass)
+
+    failing_client = MagicMock()
+    failing_client.login = AsyncMock(return_value=None)
+    failing_client.close = AsyncMock(return_value=None)
+    failing_client.api = AsyncMock(side_effect=RuntimeError("network down"))
+
+    with patch(
+        "custom_components.surepcha.__init__.SurePetcareClient",
+        return_value=failing_client,
+    ):
+        migrated = await surepetcare_init.async_migrate_entry(hass, entry)
+
+    assert migrated is False
+    assert entry.minor_version == 3
+    assert entry.subentries == {}
+
+
+@pytest.mark.asyncio
+async def test_migrate_entry_skips_already_migrated_entry(hass: HomeAssistant) -> None:
+    """An entry that already has subentries is left alone - no redundant API calls."""
+    entry = MockConfigEntry(
+        version=1,
+        minor_version=3,
+        title="Test SurePetCare entry",
+        domain=DOMAIN,
+        data={TOKEN: "abc", CLIENT_DEVICE_ID: "123"},
+        options={OPTION_DEVICES: {}, OPTION_PROPERTIES: {}},
+        subentries_data=(
+            {
+                "data": {HOUSEHOLD_ID: 555},
+                "subentry_type": "household",
+                "title": "Storm",
+                "unique_id": "555",
+            },
+        ),
+        unique_id="12345",
+    )
+    entry.add_to_hass(hass)
+
+    never_called_client = MagicMock()
+    never_called_client.login = AsyncMock(return_value=None)
+    never_called_client.close = AsyncMock(return_value=None)
+    never_called_client.api = AsyncMock(
+        side_effect=AssertionError("should not be called")
+    )
+
+    with patch(
+        "custom_components.surepcha.__init__.SurePetcareClient",
+        return_value=never_called_client,
+    ):
+        migrated = await surepetcare_init.async_migrate_entry(hass, entry)
+
+    assert migrated
+    assert entry.minor_version == 4
+    assert len(entry.subentries) == 1
+    never_called_client.api.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -1061,7 +1061,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = "==4.6.0" },
-    { name = "py-surepetcare", specifier = "==0.6.2" },
+    { name = "py-surepetcare", specifier = "==0.6.3" },
     { name = "pytest-homeassistant-custom-component", specifier = "==0.13.339" },
 ]
 
@@ -1630,15 +1630,15 @@ wheels = [
 
 [[package]]
 name = "py-surepetcare"
-version = "0.6.2"
+version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/a1/014f97522087757cf3758c44b4b90b833526e91b5de159a9a27a80e6c273/py_surepetcare-0.6.2.tar.gz", hash = "sha256:f96232c725ccc2a6e33d165ebc0483a028961ec359fb0bb541e5543bede2ba7d", size = 27930, upload-time = "2026-05-31T19:16:08.638Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/e5/39790dde3fad60e4c89aa066ad48b67bd6e4129c0c8605f59ae21c073535/py_surepetcare-0.6.3.tar.gz", hash = "sha256:d817650d307500051a62a3e8d149ae033b76794186a59968a6213ceeed33db38", size = 28417, upload-time = "2026-07-17T12:18:04.241Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/7f/495073dfd18fb0a8e6bf4b746f1b551a5102145ac99b9c086b754a64769d/py_surepetcare-0.6.2-py3-none-any.whl", hash = "sha256:09d6490ee773cc3999018ef9f8744f7a960beb0272e0a9d4b213c7d68445a2b5", size = 42765, upload-time = "2026-05-31T19:16:07.292Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/2d/fda13554ca4d5aae40942dbcf57798820339c5b55e91e8b7275b4dda5638/py_surepetcare-0.6.3-py3-none-any.whl", hash = "sha256:4c44f07e8903d115656fb6a9877daa10bd671123a2ff2966351769a40fcfa461", size = 43199, upload-time = "2026-07-17T12:18:02.69Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace the single "last feed only" per-cat sensor with `feedings_today` (visit count) and `food_today` (total/wet/dry grams), sourced from the previously-unused household timeline API - built for graphing feeding activity in HA.
- Add a household-wide `household_activity_today` sensor: a chronological feed mixing feeding visits with bowl fill/zero maintenance events, including pet and device photos; they live once each in top-level `pet_photos`/`device_photos` maps
- Migrate from one flat config entry per account to **config subentries**: one entry per Sure Petcare login, one subentry per household. Devices from different households were never meant to share ownership, and this aligns with Home Assistant's own device-registry direction (Core 2026.8 restricts a device to one subentry).
  - New logins create one subentry per household automatically (empty households skipped).
  - A household can be added later without re-authenticating (`HouseholdSubentryFlow`).
  - Existing entries migrate non-destructively: only `config_subentry_id` changes, so entity_ids/areas/history are untouched. Setup is also self-healing - a plain restart repairs any device still missing its subentry association.
- Fix an aiohttp `ClientSession` leak: the client was only closed on full HA shutdown, so every entry reload (options change, manual reload, reauth) leaked a session. Also fixed a login-failure path that leaked a client and crashed the config flow instead of showing an error.
- Cut startup time roughly in half:
  - Removed a redundant full re-fetch of every device (data was fetched once via the household chain, then fetched again by each coordinator's own first refresh).
  - Added a `SurePetcareClient` subclass (`client.py`) that runs chained follow-up API calls concurrently instead of one request at a time - no changes needed to the `surepcio` dependency itself.
  - Households, and each household's pets/devices, now load in parallel instead of sequentially.

## Test plan

- [x] `uv run pytest tests/` - 118 passed, 1 skipped, 606 snapshots passed
- [x] `uv run pre-commit run --all-files` - pyupgrade, codespell, ruff, ruff-format, mypy all clean
- [x] Verified against a real Sure Petcare account (2 households) via a diagnostic script (`scripts/dump_timeline.py`, not part of the shipped integration)
- [x] Confirmed on a live HA instance (Core 2026.7.4): existing entry migrates to subentries without device loss, self-heals a stale "no sub-entry" device association, startup time measurably improved.