### PR TITLE
Fix aiohttp session leaks in setup and config flow

### DIFF
--- a/custom_components/surepcha/__init__.py
+++ b/custom_components/surepcha/__init__.py
@@ -85,16 +85,16 @@ async def setup_devices(hass, entry) -> tuple[SurePetcareClient, list[Any]]:
     except Exception as exc:
         raise ConfigEntryAuthFailed from exc
 
-    async def on_hass_stop(event: Event) -> None:
-        """Close connection when hass stops."""
+    async def close_client(event: Event | None = None) -> None:
+        """Close the client - on hass-stop, and again on entry unload/reload."""
         await client.close()
 
-    # Setup listeners. Entry unload/reload doesn't fire EVENT_HOMEASSISTANT_STOP,
-    # so close the session on both to avoid leaking it on every reload.
+    # Both listeners are needed: hass-stop doesn't unload entries, and
+    # unload/reload doesn't fire on a full hass stop.
     entry.async_on_unload(
-        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, close_client)
     )
-    entry.async_on_unload(client.close)
+    entry.async_on_unload(close_client)
     # Fetch initial devices
     try:
         households: List[Household] = await client.api(Household.get_households())

--- a/custom_components/surepcha/__init__.py
+++ b/custom_components/surepcha/__init__.py
@@ -89,10 +89,12 @@ async def setup_devices(hass, entry) -> tuple[SurePetcareClient, list[Any]]:
         """Close connection when hass stops."""
         await client.close()
 
-    # Setup listeners
+    # Setup listeners. Entry unload/reload doesn't fire EVENT_HOMEASSISTANT_STOP,
+    # so close the session on both to avoid leaking it on every reload.
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, on_hass_stop)
     )
+    entry.async_on_unload(client.close)
     # Fetch initial devices
     try:
         households: List[Household] = await client.api(Household.get_households())

--- a/custom_components/surepcha/config_flow.py
+++ b/custom_components/surepcha/config_flow.py
@@ -59,8 +59,10 @@ class SurePetCareConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: 
             )
             errors.update(error)
 
-            entity_info, error = await self._async_fetch_entities(client)
-            errors.update(error)
+            entity_info: dict | None = None
+            if not errors:
+                entity_info, error = await self._async_fetch_entities(client)
+                errors.update(error)
             await client.close()
             if not errors:
                 logger.debug(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -30,7 +30,7 @@ from custom_components.surepcha.config_flow import (
 )
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from homeassistant.data_entry_flow import FlowResultType
 from surepcio import Household
 
@@ -176,6 +176,60 @@ async def test_user_flow(
     assert result2.get("type") is FlowResultType.CREATE_ENTRY
 
     assert result2 == snapshot
+
+
+@pytest.mark.asyncio
+async def test_user_step_skips_fetch_when_auth_has_errors() -> None:
+    """A failed login must not attempt to fetch entities with an unauthenticated
+    client - regression test for the session-leak fix's auth-failure guard."""
+    flow = SurePetCareConfigFlow()
+
+    client = MagicMock()
+    client.close = AsyncMock()
+
+    with (
+        patch.object(
+            flow,
+            "_authenticate",
+            AsyncMock(return_value=(client, {"base": "auth_failed"})),
+        ),
+        patch.object(flow, "_async_fetch_entities", AsyncMock()) as fetch_mock,
+    ):
+        result = await flow.async_step_user(
+            {"email": "test@example.com", "password": "bad-password"}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"]["base"] == "auth_failed"
+    fetch_mock.assert_not_awaited()
+    client.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_user_step_calls_fetch_when_auth_ok() -> None:
+    """A successful login still fetches entities and creates the entry."""
+    flow = SurePetCareConfigFlow()
+
+    client = MagicMock()
+    client.token = "tok"
+    client.device_id = "dev"
+    client.close = AsyncMock()
+
+    with (
+        patch.object(flow, "_authenticate", AsyncMock(return_value=(client, {}))),
+        patch.object(
+            flow,
+            "_async_fetch_entities",
+            AsyncMock(return_value=({"123": {"name": "Device", "product_id": 4}}, {})),
+        ) as fetch_mock,
+    ):
+        result = await flow.async_step_user(
+            {"email": "test@example.com", "password": "good-password"}
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    fetch_mock.assert_awaited_once_with(client)
+    client.close.assert_awaited_once()
 
 
 @pytest.mark.usefixtures("mock_surepetcare_login_control", "enable_custom_integrations")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,6 @@
 import importlib
 import inspect
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 import custom_components.surepcha.__init__ as surepetcare_init
 from custom_components.surepcha.const import CLIENT_DEVICE_ID, FACTORY, TOKEN
 import pytest
@@ -12,6 +12,7 @@ from surepcio.devices.device import PetBase, DeviceBase
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -426,3 +427,63 @@ async def test_device_registry(
                 include_disabled_entities=True,
             )
         )
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_client_closed_on_entry_unload(
+    hass: HomeAssistant,
+    mock_client: SurePetcareClient,
+    mock_config_entry: MockConfigEntry,
+    mock_devices: list[DeviceBase],
+    mock_pets: list[PetBase],
+) -> None:
+    """entry.async_on_unload(client.close) must actually run on a real
+    reload/unload - the case EVENT_HOMEASSISTANT_STOP alone doesn't cover,
+    since HA does not unload every entry on a full shutdown (see the
+    hass-stop test below). Regression test for the session leak this fixes:
+    previously the client was only ever closed on EVENT_HOMEASSISTANT_STOP,
+    so every reload (options change, manual reload, reauth) leaked the
+    previous client's aiohttp session.
+    """
+    mock_client.close = AsyncMock(return_value=None)
+    await initialize_entry(
+        hass, mock_client, mock_config_entry, mock_devices, mock_pets
+    )
+    # setup_devices() also closes the session once on its own success path
+    # (a separate, pre-existing quirk - the session gets lazily reopened by
+    # the next request) - so assert the *unload* causes one more close,
+    # rather than assuming zero closes happened before it.
+    calls_before_unload = mock_client.close.call_count
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_client.close.call_count == calls_before_unload + 1
+
+
+@pytest.mark.usefixtures("enable_custom_integrations")
+async def test_client_closed_on_hass_stop(
+    hass: HomeAssistant,
+    mock_client: SurePetcareClient,
+    mock_config_entry: MockConfigEntry,
+    mock_devices: list[DeviceBase],
+    mock_pets: list[PetBase],
+) -> None:
+    """The EVENT_HOMEASSISTANT_STOP listener must keep closing the session too:
+    ConfigEntry.async_shutdown() - what actually runs for every entry on a
+    full HA stop - only cancels the retry-setup timer, it never processes
+    async_on_unload callbacks. Without this listener, a full shutdown would
+    leak the session even though entry.async_on_unload(client.close) is
+    wired up for the reload/unload case above.
+    """
+    mock_client.close = AsyncMock(return_value=None)
+    await initialize_entry(
+        hass, mock_client, mock_config_entry, mock_devices, mock_pets
+    )
+    # See the equivalent comment in test_client_closed_on_entry_unload above.
+    calls_before_stop = mock_client.close.call_count
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
+    await hass.async_block_till_done()
+
+    assert mock_client.close.call_count == calls_before_stop + 1

--- a/uv.lock
+++ b/uv.lock
@@ -1061,7 +1061,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pre-commit", specifier = "==4.6.0" },
-    { name = "py-surepetcare", specifier = "==0.6.2" },
+    { name = "py-surepetcare", specifier = "==0.6.3" },
     { name = "pytest-homeassistant-custom-component", specifier = "==0.13.339" },
 ]
 
@@ -1630,15 +1630,15 @@ wheels = [
 
 [[package]]
 name = "py-surepetcare"
-version = "0.6.2"
+version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ec/a1/014f97522087757cf3758c44b4b90b833526e91b5de159a9a27a80e6c273/py_surepetcare-0.6.2.tar.gz", hash = "sha256:f96232c725ccc2a6e33d165ebc0483a028961ec359fb0bb541e5543bede2ba7d", size = 27930, upload-time = "2026-05-31T19:16:08.638Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/e5/39790dde3fad60e4c89aa066ad48b67bd6e4129c0c8605f59ae21c073535/py_surepetcare-0.6.3.tar.gz", hash = "sha256:d817650d307500051a62a3e8d149ae033b76794186a59968a6213ceeed33db38", size = 28417, upload-time = "2026-07-17T12:18:04.241Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/24/7f/495073dfd18fb0a8e6bf4b746f1b551a5102145ac99b9c086b754a64769d/py_surepetcare-0.6.2-py3-none-any.whl", hash = "sha256:09d6490ee773cc3999018ef9f8744f7a960beb0272e0a9d4b213c7d68445a2b5", size = 42765, upload-time = "2026-05-31T19:16:07.292Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/2d/fda13554ca4d5aae40942dbcf57798820339c5b55e91e8b7275b4dda5638/py_surepetcare-0.6.3-py3-none-any.whl", hash = "sha256:4c44f07e8903d115656fb6a9877daa10bd671123a2ff2966351769a40fcfa461", size = 43199, upload-time = "2026-07-17T12:18:02.69Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- The client session was only closed on full HA shutdown, so every entry reload (options change, manual reload, reauth) leaked the previous session's connections.
- Also skip the entity fetch and close the client when login itself already failed, instead of attempting a doomed fetch with an unauthenticated client.

## Test plan
- [x] `uv run pytest tests/` - 110 passed, 1 skipped
- [x] `uv run ruff check .` / `uv run ruff format --check .` clean on touched files